### PR TITLE
Workflows: only note reliance on write permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       # Allow use of GitHub OIDC for PyPI authentication
       id-token: write
     steps:

--- a/.github/workflows/scan-workflows.yml
+++ b/.github/workflows/scan-workflows.yml
@@ -15,11 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      # required for all workflows
+      # Write access needed to upload SARIF scan results
       security-events: write
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ defaults:
     # This also implies `set -eo pipefail` (rather than just `set -e`)
     shell: bash
 
-permissions:
-  contents: read
-
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -21,9 +21,6 @@ defaults:
     # This also implies `set -eo pipefail` (rather than just `set -e`)
     shell: bash
 
-permissions:
-  contents: read
-
 jobs:
   timestamp:
     runs-on: ubuntu-20.04
@@ -178,6 +175,7 @@ jobs:
     # Need to check the output for each matrix job separately due to GitHub matrix output limitations
     if: needs.test.outputs.want-pr-linux || needs.test.outputs.want-pr-windows || needs.test.outputs.want-pr-macos
     permissions:
+      # Creating PRs involves more than just read permissions
       contents: write
       pull-requests: write
     steps:


### PR DESCRIPTION
Repository is now public, so read permissions can be assumed.

Closes #50