### PR TITLE
Update docs URLs, add OpenGraph metadata

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,6 +27,6 @@ the team is available through the `#dev-chat` channel within the
 
 ## Development Documentation
 
-Our [development documentation](https://lmstudio-ai.github.io/venvstacks/development/)
+Our [development documentation](https://venvstacks.lmstudio.ai/development/)
 contains details on how to get started with contributing to `venvstacks`,
 and details of our development processes.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 
 See the fragment files in the `changelog.d directory`_.
 
-.. _changelog.d directory: https://github.com/lmstudio-ai/venvstacks/tree/master/changelog.d
+.. _changelog.d directory: https://github.com/lmstudio-ai/venvstacks/tree/main/changelog.d
 
 
 .. scriv-insert-here

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ While the layers are archived and published separately, their dependency locking
 allowing the application layers to share dependencies installed in the framework layers,
 and the framework layers to share dependencies installed in the runtime layers.
 
-Refer to the [Project Overview](https://lmstudio-ai.github.io/venvstacks/overview/) for an
+Refer to the [Project Overview](https://venvstacks.lmstudio.ai/overview/) for an
 example of specifying, locking, building, and publishing a set of environment stacks.
 
 

--- a/changelog.d/20241101_003158_ncoghlan_update_docs_url.rst
+++ b/changelog.d/20241101_003158_ncoghlan_update_docs_url.rst
@@ -1,0 +1,42 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+Changed
+-------
+
+- Update docs URL to `https://venvstacks.lmstudio.ai`__
+
+- Add OpenGraph metadata to docs landing page
+
+- Resolved several broken links in the documentation
+
+- Documentation is now marked as being unversioned
+  (it is published directly from the main branch)
+
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "venvstacks"
 copyright = "2024, Element Labs Inc."
 author = "LM Studio"
-release = "0.1"
+release = "latest" # Docs are currently unversioned
 
 
 # -- General configuration ---------------------------------------------------
@@ -33,6 +33,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "furo"
 html_static_path = ["_static"]
+
+# Docs are published directly to GitHub pages, consider them to be unversioned
+html_title = "venvstacks documentation"
 
 # Disable the generation of the various indexes
 html_use_modindex = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,12 @@
 Virtual Environment Stacks
 ==========================
 
+.. meta::
+   :og:title: venvstacks - venvstacks Documentation
+   :og:type: website
+   :og:url: https://venvstacks.lmstudio.ai/
+   :og:description: Virtual Environment Stacks for Python - venvstacks Documentation
+
 Machine learning and AI libraries for Python are big. Really big. Nobody wants to download
 and install multiple copies of :pypi:`PyTorch <torch>` or :pypi:`CUDA <cuda-python>` if
 they can reasonably avoid it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ venvstacks = "venvstacks.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/lmstudio-ai/venvstacks"
-Documentation = "https://lmstudio-ai.github.io/venvstacks/"
+Documentation = "https://venvstacks.lmstudio.ai/"
 Issues = "https://github.com/lmstudio-ai/venvstacks/issues"
-Changelog = "https://lmstudio-ai.github.io/venvstacks/changelog/"
+Changelog = "https://venvstacks.lmstudio.ai/changelog/"
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
Chrome complained about the `lmstudio-ai` subdomain being too close to the main LMStudio domain name at `lmstudio.ai`.

Fixing this prompted several other URL related improvements.