### PR TITLE
Temporary Fix for Typer breaking changes

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "bootstrap", "dev", "docs"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:6aeecbbca3ae78365eaedbfdb879aac15904991e06a0edac3a51a347814071bd"
+content_hash = "sha256:12fc9c0a115230f1cdf44fe4927e0d17ee5275ba7a6d8d0361c29ed783773064"
 
 [[metadata.targets]]
 requires_python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # control over whether files are symlinked or copied between the environments
     "uv>=0.2.33",
     # Typer is used for the CLI interface. Install 'rich-cli' extra for enhanced features.
-    "typer-slim>=0.12.4",
+    "typer-slim==0.12.5"
 ]
 requires-python = ">=3.11"
 readme = "README.md"


### PR DESCRIPTION
This freezes the version of the package `typer-slim` to `0.12.5` as a temporary fix for typer-breaking changes so users installing this from `pipx` can still use the current version

Fixes #96 


