### PR TITLE
Remove directories in /bin when ensuring portability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,6 @@ See the fragment files in the `changelog.d directory`_.
 
 .. scriv-insert-here
 
-.. _changelog-0.3.0:
-
-0.3.0 — 2024-12-31
-==================
-
 Fixed
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ See the fragment files in the `changelog.d directory`_.
 
 .. scriv-insert-here
 
+.. _changelog-0.3.0:
+
+0.3.0 — 2024-12-31
+==================
+
+Fixed
+-----
+
+- Remove directories from /bin when building layers
+
 .. _changelog-0.2.1:
 
 0.2.1 — 2024-12-05

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -1388,10 +1388,13 @@ class LayerEnvBase(ABC):
     def _ensure_portability(self) -> None:
         # Wrapper and activation scripts are not used on deployment targets,
         # so drop them entirely rather than making them portable
-        for executable in self.executables_path.iterdir():
-            if not executable.name.lower().startswith("python"):
-                print(f"    Dropping potentially non-portable file {str(executable)!r}")
-                executable.unlink()
+        for item in self.executables_path.iterdir():
+            if not item.name.lower().startswith("python"):
+                print(f"    Dropping potentially non-portable file {str(item)!r}")
+                if item.is_dir():
+                    shutil.rmtree(item)
+                else:
+                    item.unlink()
         # Symlinks within the build folder should be relative
         # Symlinks outside the build folder shouldn't exist
         build_path = self.build_path

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -1389,12 +1389,11 @@ class LayerEnvBase(ABC):
         # Wrapper and activation scripts are not used on deployment targets,
         # so drop them entirely rather than making them portable
         for item in self.executables_path.iterdir():
-            if not item.name.lower().startswith("python"):
+            if item.is_dir():
+                shutil.rmtree(item)
+            elif not item.name.lower().startswith("python"):
                 print(f"    Dropping potentially non-portable file {str(item)!r}")
-                if item.is_dir():
-                    shutil.rmtree(item)
-                else:
-                    item.unlink()
+                item.unlink()
         # Symlinks within the build folder should be relative
         # Symlinks outside the build folder shouldn't exist
         build_path = self.build_path

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -1390,6 +1390,7 @@ class LayerEnvBase(ABC):
         # so drop them entirely rather than making them portable
         for item in self.executables_path.iterdir():
             if item.is_dir():
+                print(f"    Dropping directory {str(item)!r}")
                 shutil.rmtree(item)
             elif not item.name.lower().startswith("python"):
                 print(f"    Dropping potentially non-portable file {str(item)!r}")


### PR DESCRIPTION
The package `xlsxwriter` places a `__pycache__` directory in the build's `bin` directory. Because of this, `_ensure_portability` causes the fails the build when it tries to unlink a non-empty directory. This PR deletes all directories within `bin`.