### PR TITLE
Pass `--only-binary :all:` to compile step

### DIFF
--- a/docs/changelog.d/20250324_223904_ncoghlan_require_binaries_when_locking.rst
+++ b/docs/changelog.d/20250324_223904_ncoghlan_require_binaries_when_locking.rst
@@ -1,20 +1,3 @@
-.. Defined changelog categories:
-..   - Removed
-..   - Added
-..   - Changed
-..   - Deprecated
-..   - Fixed
-..   - Security
-..
-.. Replace "Category" below with the relevant category name.
-.. Adjust the heading underline to match the chosen category name.
-.. For top level release notes, delete the category header entirely.
-.. Update the referenced issue number as appropriate.
-.. "resolved" works for most categories, but replace the verb as necessary.
-.. Use `:pr:`NN` to refer to pull requests. Other Sphinx roles also work here.
-..
-.. Deleting this header after editing is recommended (it contains 16 lines).
-
 Fixed
 -----
 

--- a/docs/changelog.d/20250324_223904_ncoghlan_require_binaries_when_locking.rst
+++ b/docs/changelog.d/20250324_223904_ncoghlan_require_binaries_when_locking.rst
@@ -1,0 +1,23 @@
+.. Defined changelog categories:
+..   - Removed
+..   - Added
+..   - Changed
+..   - Deprecated
+..   - Fixed
+..   - Security
+..
+.. Replace "Category" below with the relevant category name.
+.. Adjust the heading underline to match the chosen category name.
+.. For top level release notes, delete the category header entirely.
+.. Update the referenced issue number as appropriate.
+.. "resolved" works for most categories, but replace the verb as necessary.
+.. Use `:pr:`NN` to refer to pull requests. Other Sphinx roles also work here.
+..
+.. Deleting this header after editing is recommended (it contains 16 lines).
+
+Fixed
+-----
+
+- `--only-binary ":all:"` is now passed when locking the layers in addition
+  to being passed when creating the layer environments. This avoids emitting
+  requirements that can't be installed (resolved in :issue:`102`).

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -148,7 +148,8 @@ class PackageIndexConfig:
         ]
 
     def _get_common_pip_args(self) -> list[str]:
-        result = []
+        # Local wheel builds are expected for any source-only dependencies
+        result = ["--only-binary", ":all:"]
         if not self.query_default_index:
             result.append("--no-index")
         for local_wheel_path in self.local_wheel_paths:
@@ -1318,8 +1319,6 @@ class LayerEnvBase(ABC):
             "install",
             "--no-warn-script-location",
             *self.index_config._get_pip_install_args(),
-            "--only-binary",
-            ":all:",
             "--no-deps",
             "--upgrade",
             *pip_install_args,

--- a/tests/test_index_config.py
+++ b/tests/test_index_config.py
@@ -13,10 +13,16 @@ class TestDefaultOptions:
     TEST_CONFIG = PackageIndexConfig()
 
     def test_uv_pip_compile(self) -> None:
-        assert self.TEST_CONFIG._get_uv_pip_compile_args() == []
+        assert self.TEST_CONFIG._get_uv_pip_compile_args() == [
+            "--only-binary",
+            ":all:",
+        ]
 
     def test_pip_install(self) -> None:
-        assert self.TEST_CONFIG._get_pip_install_args() == []
+        assert self.TEST_CONFIG._get_pip_install_args() == [
+            "--only-binary",
+            ":all:",
+        ]
 
 
 class TestConfiguredOptions:
@@ -29,6 +35,8 @@ class TestConfiguredOptions:
     def test_uv_pip_compile(self) -> None:
         # There are currently no locking specific args
         assert self.TEST_CONFIG._get_uv_pip_compile_args() == [
+            "--only-binary",
+            ":all:",
             "--no-index",
             "--find-links",
             self.WHEEL_DIR,
@@ -37,6 +45,8 @@ class TestConfiguredOptions:
     def test_pip_install(self) -> None:
         # There are currently no installation specific args
         assert self.TEST_CONFIG._get_pip_install_args() == [
+            "--only-binary",
+            ":all:",
             "--no-index",
             "--find-links",
             self.WHEEL_DIR,


### PR DESCRIPTION
Avoid emitting lock files that the installation step can't install.

Closes #102