### PR TITLE
Improve dynamic linking across layers

### DIFF
--- a/tests/expected-output-config.toml
+++ b/tests/expected-output-config.toml
@@ -33,4 +33,4 @@ UV_EXCLUDE_NEWER="2024-10-15 00:00:00+00:00"
 # Metadata updates can also be requested when the
 # launch module content in the sample project changes
 
-# Last requested update: dynamic linking across layers
+# Last requested update: improved dynamic linking across layers

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-client.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "8362ea5262fd9d779ea454d5ecda0ca5aa29d327a0793cff4271b4fec18e767e"
+    "sha256": "b7f3d4535a8a335ee988ebbc5bc5113c1df0bdfd4c92b06e7968248f43050b65"
   },
   "archive_name": "app-scipy-client.tar.xz",
-  "archive_size": 4700,
+  "archive_size": 3700,
   "bound_to_implementation": false,
   "install_target": "app-scipy-client",
   "layer_name": "app-scipy-client",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-import.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-import.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "f573ac66e8721f059f8affa4d6dddbf757992610d2486f98d9408f0d5aca50e1"
+    "sha256": "19b07e1326f8aaaa44dd6a1fd3f99a102766b28e903ec59a02f4f085cd278d48"
   },
   "archive_name": "app-scipy-import@1.tar.xz",
-  "archive_size": 4604,
+  "archive_size": 3600,
   "bound_to_implementation": false,
   "install_target": "app-scipy-import@1",
   "layer_name": "app-scipy-import",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-sklearn-import.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-sklearn-import.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256:f48aeede7d02ae34856f0149bb15b3cd4bebd3a82911cfd4e2e1c2639b8cd53c",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "b4db4ae0878ef92997b3477e7cecf19374662daeb2b66cad04f1da7441566386"
+    "sha256": "792e3de71491755b2349e69e5786ca5e8b6b5792d12ce6ab53f3482a3f6f78f1"
   },
   "archive_name": "app-sklearn-import.tar.xz",
-  "archive_size": 4604,
+  "archive_size": 3596,
   "bound_to_implementation": false,
   "install_target": "app-sklearn-import",
   "layer_name": "app-sklearn-import",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.11.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "faef1655a6a655db36f99d31a59a1b58f5ad01059333dbc48869328944c226d0"
+    "sha256": "196fac3012aff6824e0c3fd4f414cdafa73ddfe4096310618af330538a24020b"
   },
   "archive_name": "cpython-3.11.tar.xz",
-  "archive_size": 29800548,
+  "archive_size": 29799444,
   "bound_to_implementation": true,
   "install_target": "cpython-3.11",
   "layer_name": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.12.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "3ab5b119650c1efefb9b0465bcadab0e49c451853dc5793e78abf39a72b88dbd"
+    "sha256": "802b6eaefe72c037f449d2a1a684122376a34a21334e318e18696b6e187946f9"
   },
   "archive_name": "cpython-3.12.tar.xz",
-  "archive_size": 42577568,
+  "archive_size": 42576540,
   "bound_to_implementation": true,
   "install_target": "cpython-3.12",
   "layer_name": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-http-client.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "3ca518277d30661f28cb2f4bfe139ca499cbd817ef7c5530208ef104704d48bf"
+    "sha256": "38522fe2efaea4abc4e681afc36360aed2bdcc06c300e13531847455e6577a76"
   },
   "archive_name": "framework-http-client.tar.xz",
-  "archive_size": 365580,
+  "archive_size": 364692,
   "bound_to_implementation": false,
   "install_target": "framework-http-client",
   "layer_name": "framework-http-client",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-scipy.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "65f6467c46174607f970b10ad160c53e76de470b726fb2be01a001b6e170094a"
+    "sha256": "01a7c96ec3ca08a32ce0d7a4fbac94412e29965be90bd5c2aac337f4f68f57d3"
   },
   "archive_name": "framework-scipy@1.tar.xz",
-  "archive_size": 23959820,
+  "archive_size": 23960024,
   "bound_to_implementation": false,
   "install_target": "framework-scipy@1",
   "layer_name": "framework-scipy",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-sklearn.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "b67b9529eb0f4977cc7046ef43c662e31e901bf40c1ec44fef0cc09b879a45d5"
+    "sha256": "e15a7d3cab5462be8bec0b67fc6a5bb4b95caf929a9931014ce6f24575da8f80"
   },
   "archive_name": "framework-sklearn.tar.xz",
-  "archive_size": 30374120,
+  "archive_size": 30384924,
   "bound_to_implementation": false,
   "install_target": "framework-sklearn",
   "layer_name": "framework-sklearn",

--- a/tests/sample_project/expected_manifests/linux_x86_64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/venvstacks.json
@@ -6,10 +6,10 @@
         "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "f573ac66e8721f059f8affa4d6dddbf757992610d2486f98d9408f0d5aca50e1"
+          "sha256": "19b07e1326f8aaaa44dd6a1fd3f99a102766b28e903ec59a02f4f085cd278d48"
         },
         "archive_name": "app-scipy-import@1.tar.xz",
-        "archive_size": 4604,
+        "archive_size": 3600,
         "bound_to_implementation": false,
         "install_target": "app-scipy-import@1",
         "layer_name": "app-scipy-import",
@@ -28,10 +28,10 @@
         "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "8362ea5262fd9d779ea454d5ecda0ca5aa29d327a0793cff4271b4fec18e767e"
+          "sha256": "b7f3d4535a8a335ee988ebbc5bc5113c1df0bdfd4c92b06e7968248f43050b65"
         },
         "archive_name": "app-scipy-client.tar.xz",
-        "archive_size": 4700,
+        "archive_size": 3700,
         "bound_to_implementation": false,
         "install_target": "app-scipy-client",
         "layer_name": "app-scipy-client",
@@ -51,10 +51,10 @@
         "app_launch_module_hash": "sha256:f48aeede7d02ae34856f0149bb15b3cd4bebd3a82911cfd4e2e1c2639b8cd53c",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "b4db4ae0878ef92997b3477e7cecf19374662daeb2b66cad04f1da7441566386"
+          "sha256": "792e3de71491755b2349e69e5786ca5e8b6b5792d12ce6ab53f3482a3f6f78f1"
         },
         "archive_name": "app-sklearn-import.tar.xz",
-        "archive_size": 4604,
+        "archive_size": 3596,
         "bound_to_implementation": false,
         "install_target": "app-sklearn-import",
         "layer_name": "app-sklearn-import",
@@ -73,10 +73,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "65f6467c46174607f970b10ad160c53e76de470b726fb2be01a001b6e170094a"
+          "sha256": "01a7c96ec3ca08a32ce0d7a4fbac94412e29965be90bd5c2aac337f4f68f57d3"
         },
         "archive_name": "framework-scipy@1.tar.xz",
-        "archive_size": 23959820,
+        "archive_size": 23960024,
         "bound_to_implementation": false,
         "install_target": "framework-scipy@1",
         "layer_name": "framework-scipy",
@@ -91,10 +91,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "b67b9529eb0f4977cc7046ef43c662e31e901bf40c1ec44fef0cc09b879a45d5"
+          "sha256": "e15a7d3cab5462be8bec0b67fc6a5bb4b95caf929a9931014ce6f24575da8f80"
         },
         "archive_name": "framework-sklearn.tar.xz",
-        "archive_size": 30374120,
+        "archive_size": 30384924,
         "bound_to_implementation": false,
         "install_target": "framework-sklearn",
         "layer_name": "framework-sklearn",
@@ -109,10 +109,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "3ca518277d30661f28cb2f4bfe139ca499cbd817ef7c5530208ef104704d48bf"
+          "sha256": "38522fe2efaea4abc4e681afc36360aed2bdcc06c300e13531847455e6577a76"
         },
         "archive_name": "framework-http-client.tar.xz",
-        "archive_size": 365580,
+        "archive_size": 364692,
         "bound_to_implementation": false,
         "install_target": "framework-http-client",
         "layer_name": "framework-http-client",
@@ -129,10 +129,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "faef1655a6a655db36f99d31a59a1b58f5ad01059333dbc48869328944c226d0"
+          "sha256": "196fac3012aff6824e0c3fd4f414cdafa73ddfe4096310618af330538a24020b"
         },
         "archive_name": "cpython-3.11.tar.xz",
-        "archive_size": 29800548,
+        "archive_size": 29799444,
         "bound_to_implementation": true,
         "install_target": "cpython-3.11",
         "layer_name": "cpython-3.11",
@@ -146,10 +146,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "3ab5b119650c1efefb9b0465bcadab0e49c451853dc5793e78abf39a72b88dbd"
+          "sha256": "802b6eaefe72c037f449d2a1a684122376a34a21334e318e18696b6e187946f9"
         },
         "archive_name": "cpython-3.12.tar.xz",
-        "archive_size": 42577568,
+        "archive_size": 42576540,
         "bound_to_implementation": true,
         "install_target": "cpython-3.12",
         "layer_name": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-client.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "ba72801156d79b369f9ee87762b77e75c588c8e0389d723a835101ba38cd23bb"
+    "sha256": "985136d07f0256ad49e1ba23f05adc33634390dd2010def5ac72627bd8049e7b"
   },
   "archive_name": "app-scipy-client.tar.xz",
-  "archive_size": 4676,
+  "archive_size": 3676,
   "bound_to_implementation": false,
   "install_target": "app-scipy-client",
   "layer_name": "app-scipy-client",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-import.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-import.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "d81b757063fa02587c644bc24e9ac338b2508d8ec65366670505afea92dc09fc"
+    "sha256": "c9aedc5162463983959e4d71c955d918ea647fd5c331fc23163f2a646cdfa2e5"
   },
   "archive_name": "app-scipy-import@1.tar.xz",
-  "archive_size": 4576,
+  "archive_size": 3572,
   "bound_to_implementation": false,
   "install_target": "app-scipy-import@1",
   "layer_name": "app-scipy-import",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.11.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "3fcbaf54145306892d08b3f7fe3b935d3ab9b9f3c53ee4f02dba65594a7f3454"
+    "sha256": "e20b4d0def22cc496629edfa2c54d6f00c6d69ebd8b9d2078355d5f741c6afe6"
   },
   "archive_name": "cpython-3.11.tar.xz",
-  "archive_size": 15034228,
+  "archive_size": 15033212,
   "bound_to_implementation": true,
   "install_target": "cpython-3.11",
   "layer_name": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.12.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "380c9737b8e5c5014c92ce44e83b954e0c2631520a2c49b27706d8e6e034133d"
+    "sha256": "8f2b6b7382fee4468382f54b407a27c6c6c088fd4e2dec19ba7302d2c8d785f6"
   },
   "archive_name": "cpython-3.12.tar.xz",
-  "archive_size": 13669352,
+  "archive_size": 13668324,
   "bound_to_implementation": true,
   "install_target": "cpython-3.12",
   "layer_name": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-http-client.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "08415aec62d73bd41bb7fafd6d034038ebfea4c0401f24693f5ed96cf06b9dfd"
+    "sha256": "81f8ff666adc27f0a12f170ad8137cdb70102d8d27bcbfb9e3bd31588de2743e"
   },
   "archive_name": "framework-http-client.tar.xz",
-  "archive_size": 365712,
+  "archive_size": 364732,
   "bound_to_implementation": false,
   "install_target": "framework-http-client",
   "layer_name": "framework-http-client",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-scipy.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "d7ab82df33c4a4645f0ca3a9dd0d83cc7e23513c793a97ab6a6a5e2fe9e87253"
+    "sha256": "bdfaead153b9cbc0a10cef3b2e7ca5c5cfb24cc17b304093239cf64c255200df"
   },
   "archive_name": "framework-scipy@1.tar.xz",
-  "archive_size": 15081312,
+  "archive_size": 15081544,
   "bound_to_implementation": false,
   "install_target": "framework-scipy@1",
   "layer_name": "framework-scipy",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-sklearn.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "066a1526066bf98d8b52797244999683601447560f4597200f978afba7c4ccf2"
+    "sha256": "b06b53dc17c4e4fe0b07acd5b72b252865dac313ea0eb6d57ce153a4bd98e298"
   },
   "archive_name": "framework-sklearn.tar.xz",
-  "archive_size": 20691540,
+  "archive_size": 20689220,
   "bound_to_implementation": false,
   "install_target": "framework-sklearn",
   "layer_name": "framework-sklearn",

--- a/tests/sample_project/expected_manifests/macosx_arm64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/venvstacks.json
@@ -6,10 +6,10 @@
         "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "d81b757063fa02587c644bc24e9ac338b2508d8ec65366670505afea92dc09fc"
+          "sha256": "c9aedc5162463983959e4d71c955d918ea647fd5c331fc23163f2a646cdfa2e5"
         },
         "archive_name": "app-scipy-import@1.tar.xz",
-        "archive_size": 4576,
+        "archive_size": 3572,
         "bound_to_implementation": false,
         "install_target": "app-scipy-import@1",
         "layer_name": "app-scipy-import",
@@ -28,10 +28,10 @@
         "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "ba72801156d79b369f9ee87762b77e75c588c8e0389d723a835101ba38cd23bb"
+          "sha256": "985136d07f0256ad49e1ba23f05adc33634390dd2010def5ac72627bd8049e7b"
         },
         "archive_name": "app-scipy-client.tar.xz",
-        "archive_size": 4676,
+        "archive_size": 3676,
         "bound_to_implementation": false,
         "install_target": "app-scipy-client",
         "layer_name": "app-scipy-client",
@@ -51,10 +51,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "d7ab82df33c4a4645f0ca3a9dd0d83cc7e23513c793a97ab6a6a5e2fe9e87253"
+          "sha256": "bdfaead153b9cbc0a10cef3b2e7ca5c5cfb24cc17b304093239cf64c255200df"
         },
         "archive_name": "framework-scipy@1.tar.xz",
-        "archive_size": 15081312,
+        "archive_size": 15081544,
         "bound_to_implementation": false,
         "install_target": "framework-scipy@1",
         "layer_name": "framework-scipy",
@@ -69,10 +69,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "066a1526066bf98d8b52797244999683601447560f4597200f978afba7c4ccf2"
+          "sha256": "b06b53dc17c4e4fe0b07acd5b72b252865dac313ea0eb6d57ce153a4bd98e298"
         },
         "archive_name": "framework-sklearn.tar.xz",
-        "archive_size": 20691540,
+        "archive_size": 20689220,
         "bound_to_implementation": false,
         "install_target": "framework-sklearn",
         "layer_name": "framework-sklearn",
@@ -87,10 +87,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "08415aec62d73bd41bb7fafd6d034038ebfea4c0401f24693f5ed96cf06b9dfd"
+          "sha256": "81f8ff666adc27f0a12f170ad8137cdb70102d8d27bcbfb9e3bd31588de2743e"
         },
         "archive_name": "framework-http-client.tar.xz",
-        "archive_size": 365712,
+        "archive_size": 364732,
         "bound_to_implementation": false,
         "install_target": "framework-http-client",
         "layer_name": "framework-http-client",
@@ -107,10 +107,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "3fcbaf54145306892d08b3f7fe3b935d3ab9b9f3c53ee4f02dba65594a7f3454"
+          "sha256": "e20b4d0def22cc496629edfa2c54d6f00c6d69ebd8b9d2078355d5f741c6afe6"
         },
         "archive_name": "cpython-3.11.tar.xz",
-        "archive_size": 15034228,
+        "archive_size": 15033212,
         "bound_to_implementation": true,
         "install_target": "cpython-3.11",
         "layer_name": "cpython-3.11",
@@ -124,10 +124,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "380c9737b8e5c5014c92ce44e83b954e0c2631520a2c49b27706d8e6e034133d"
+          "sha256": "8f2b6b7382fee4468382f54b407a27c6c6c088fd4e2dec19ba7302d2c8d785f6"
         },
         "archive_name": "cpython-3.12.tar.xz",
-        "archive_size": 13669352,
+        "archive_size": 13668324,
         "bound_to_implementation": true,
         "install_target": "cpython-3.12",
         "layer_name": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-client.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "8332a557cf6e5e990aeb5f3412bcffb105cf4d759822e880a047eb92f3155f15"
+    "sha256": "3059c2c4f988e486430b4b9ce375046edc9af5dbb81850f37319e40bd222a2e6"
   },
   "archive_name": "app-scipy-client.zip",
-  "archive_size": 259124,
+  "archive_size": 257817,
   "bound_to_implementation": true,
   "install_target": "app-scipy-client",
   "layer_name": "app-scipy-client",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-import.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-import.json
@@ -3,10 +3,10 @@
   "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "38cd53b5a16db74486a3563f798cc4e1248cf654bd6af3282a984816c93b3d33"
+    "sha256": "4bd632c07e029c9c7afbe27d466980f58ba4d0d86fc8d1c0fd57e371659b276a"
   },
   "archive_name": "app-scipy-import@1.zip",
-  "archive_size": 258684,
+  "archive_size": 257377,
   "bound_to_implementation": true,
   "install_target": "app-scipy-import@1",
   "layer_name": "app-scipy-import",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.11.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "4aff1955b54ffb9bea5025634259a86f7a7b660b4a5b956dc8a018a13732fb8c"
+    "sha256": "1543cea47a97848f31a60968011d4ceeffaf288aa739d0a594f309e1f56f36af"
   },
   "archive_name": "cpython-3.11.zip",
-  "archive_size": 50102570,
+  "archive_size": 50101263,
   "bound_to_implementation": true,
   "install_target": "cpython-3.11",
   "layer_name": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.12.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "5ebb914e827ec28a810a79a84aef326b506a26769e43b0336f02a76995da9008"
+    "sha256": "ec234b9b84c8d8d00e798dbc232f008f628ded85b13e04d310ca086748c29fa4"
   },
   "archive_name": "cpython-3.12.zip",
-  "archive_size": 49924570,
+  "archive_size": 49923263,
   "bound_to_implementation": true,
   "install_target": "cpython-3.12",
   "layer_name": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-http-client.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "a0108099266b739f3c962351d134eece9eedb7be5cc4fab6bdb772c7ad862c2a"
+    "sha256": "d9b1f53389152fdb749dd066b638f02a44f02a6d7460af96053a4700f2883bd9"
   },
   "archive_name": "framework-http-client.zip",
-  "archive_size": 821941,
+  "archive_size": 820634,
   "bound_to_implementation": true,
   "install_target": "framework-http-client",
   "layer_name": "framework-http-client",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-scipy.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "279eaec597bb09c4fff8091e6a0d39637edc04e7662952a8542b24c6b0009ac4"
+    "sha256": "8add3cce70bd2c7a0178c18f76185a0651cc049d7c67bdfd2368326327bac832"
   },
   "archive_name": "framework-scipy@1.zip",
-  "archive_size": 45089232,
+  "archive_size": 45087925,
   "bound_to_implementation": true,
   "install_target": "framework-scipy@1",
   "layer_name": "framework-scipy",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-sklearn.json
@@ -1,10 +1,10 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "260f59fbbd1b2452c2c5b29d79738c8509ceee18525cefb9116e896d8ca036b6"
+    "sha256": "c19a244762c8d098c8f4b056323a5be7c39bc954989b75beab8729b3cc307ff9"
   },
   "archive_name": "framework-sklearn.zip",
-  "archive_size": 56190143,
+  "archive_size": 56188836,
   "bound_to_implementation": true,
   "install_target": "framework-sklearn",
   "layer_name": "framework-sklearn",

--- a/tests/sample_project/expected_manifests/win_amd64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/win_amd64/venvstacks.json
@@ -6,10 +6,10 @@
         "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "38cd53b5a16db74486a3563f798cc4e1248cf654bd6af3282a984816c93b3d33"
+          "sha256": "4bd632c07e029c9c7afbe27d466980f58ba4d0d86fc8d1c0fd57e371659b276a"
         },
         "archive_name": "app-scipy-import@1.zip",
-        "archive_size": 258684,
+        "archive_size": 257377,
         "bound_to_implementation": true,
         "install_target": "app-scipy-import@1",
         "layer_name": "app-scipy-import",
@@ -28,10 +28,10 @@
         "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "8332a557cf6e5e990aeb5f3412bcffb105cf4d759822e880a047eb92f3155f15"
+          "sha256": "3059c2c4f988e486430b4b9ce375046edc9af5dbb81850f37319e40bd222a2e6"
         },
         "archive_name": "app-scipy-client.zip",
-        "archive_size": 259124,
+        "archive_size": 257817,
         "bound_to_implementation": true,
         "install_target": "app-scipy-client",
         "layer_name": "app-scipy-client",
@@ -51,10 +51,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "279eaec597bb09c4fff8091e6a0d39637edc04e7662952a8542b24c6b0009ac4"
+          "sha256": "8add3cce70bd2c7a0178c18f76185a0651cc049d7c67bdfd2368326327bac832"
         },
         "archive_name": "framework-scipy@1.zip",
-        "archive_size": 45089232,
+        "archive_size": 45087925,
         "bound_to_implementation": true,
         "install_target": "framework-scipy@1",
         "layer_name": "framework-scipy",
@@ -69,10 +69,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "260f59fbbd1b2452c2c5b29d79738c8509ceee18525cefb9116e896d8ca036b6"
+          "sha256": "c19a244762c8d098c8f4b056323a5be7c39bc954989b75beab8729b3cc307ff9"
         },
         "archive_name": "framework-sklearn.zip",
-        "archive_size": 56190143,
+        "archive_size": 56188836,
         "bound_to_implementation": true,
         "install_target": "framework-sklearn",
         "layer_name": "framework-sklearn",
@@ -87,10 +87,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "a0108099266b739f3c962351d134eece9eedb7be5cc4fab6bdb772c7ad862c2a"
+          "sha256": "d9b1f53389152fdb749dd066b638f02a44f02a6d7460af96053a4700f2883bd9"
         },
         "archive_name": "framework-http-client.zip",
-        "archive_size": 821941,
+        "archive_size": 820634,
         "bound_to_implementation": true,
         "install_target": "framework-http-client",
         "layer_name": "framework-http-client",
@@ -107,10 +107,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "4aff1955b54ffb9bea5025634259a86f7a7b660b4a5b956dc8a018a13732fb8c"
+          "sha256": "1543cea47a97848f31a60968011d4ceeffaf288aa739d0a594f309e1f56f36af"
         },
         "archive_name": "cpython-3.11.zip",
-        "archive_size": 50102570,
+        "archive_size": 50101263,
         "bound_to_implementation": true,
         "install_target": "cpython-3.11",
         "layer_name": "cpython-3.11",
@@ -124,10 +124,10 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "5ebb914e827ec28a810a79a84aef326b506a26769e43b0336f02a76995da9008"
+          "sha256": "ec234b9b84c8d8d00e798dbc232f008f628ded85b13e04d310ca086748c29fa4"
         },
         "archive_name": "cpython-3.12.zip",
-        "archive_size": 49924570,
+        "archive_size": 49923263,
         "bound_to_implementation": true,
         "install_target": "cpython-3.12",
         "layer_name": "cpython-3.12",


### PR DESCRIPTION
* wrapper script uses relative paths, so emit it at build time and then leave it alone in the postinstall script
* accept runtime dynamic library load path overrides
* handle venvs that are set up with a multi-step symlink chain

Implementation improvements for #38