### PR TITLE
Further layer lock invalidation fixes

### DIFF
--- a/docs/api/stacks/venvstacks.stacks.EnvironmentLock.rst
+++ b/docs/api/stacks/venvstacks.stacks.EnvironmentLock.rst
@@ -10,6 +10,8 @@ venvstacks.stacks.EnvironmentLock
 
    .. autosummary::
 
+      ~EnvironmentLock.append_other_input
+      ~EnvironmentLock.extend_other_inputs
       ~EnvironmentLock.get_deployed_name
       ~EnvironmentLock.invalidate_lock
       ~EnvironmentLock.load_valid_metadata
@@ -25,6 +27,7 @@ venvstacks.stacks.EnvironmentLock
       ~EnvironmentLock.lock_version
       ~EnvironmentLock.locked_at
       ~EnvironmentLock.locked_requirements_path
+      ~EnvironmentLock.other_inputs
       ~EnvironmentLock.requirements_hash
       ~EnvironmentLock.versioned
 

--- a/docs/api/stacks/venvstacks.stacks.EnvironmentLockMetadata.rst
+++ b/docs/api/stacks/venvstacks.stacks.EnvironmentLockMetadata.rst
@@ -11,6 +11,7 @@ venvstacks.stacks.EnvironmentLockMetadata
 
       ~EnvironmentLockMetadata.requirements_hash
       ~EnvironmentLockMetadata.lock_input_hash
+      ~EnvironmentLockMetadata.other_inputs_hash
       ~EnvironmentLockMetadata.lock_version
       ~EnvironmentLockMetadata.locked_at
 

--- a/docs/file-formats.rst
+++ b/docs/file-formats.rst
@@ -338,6 +338,7 @@ Environment lock metadata files saved alongside the layer's transitively locked 
 
    requirements_hash: str  # Uses "algorithm:hexdigest" format
    lock_input_hash: str    # Uses "algorithm:hexdigest" format
+   other_inputs_hash: str  # Uses "algorithm:hexdigest" format
    lock_version: int       # Auto-incremented from previous lock metadata
    locked_at: str          # ISO formatted date/time value
 

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -194,6 +194,7 @@ class EnvironmentLockMetadata(TypedDict):
     # fmt: off
     requirements_hash: str  # Uses "algorithm:hexdigest" format
     lock_input_hash: str    # Uses "algorithm:hexdigest" format
+    other_inputs_hash: str  # Uses "algorithm:hexdigest" format
     lock_version: int       # Auto-incremented from previous lock metadata
     locked_at: str          # ISO formatted date/time value
     # fmt: on
@@ -207,11 +208,13 @@ class EnvironmentLock:
     """Layered environment dependency locking management."""
 
     locked_requirements_path: Path
-    declared_requirements: Sequence[str]
+    declared_requirements: tuple[str, ...]
+    other_inputs: tuple[str, ...]
     versioned: bool = False
     _lock_input_path: Path = field(init=False, repr=False)
     _lock_input_hash: str = field(init=False, repr=False)
     _requirements_hash: str | None = field(init=False, repr=False)
+    _other_inputs_hash: str = field(init=False, repr=False)
     _lock_metadata_path: Path = field(init=False, repr=False)
     _last_locked: datetime | None = field(init=False, repr=False)
     _lock_version: int | None = field(init=False, repr=False)
@@ -219,7 +222,7 @@ class EnvironmentLock:
     def __post_init__(self) -> None:
         req_path = self.locked_requirements_path
         self._lock_input_path = req_path.with_suffix(".in")
-        self._update_req_hashes()
+        self._update_hashes()
         self._lock_metadata_path = Path(f"{req_path}.json")
         self._last_locked = last_locked = self._get_last_locked_time()
         if last_locked:
@@ -243,6 +246,16 @@ class EnvironmentLock:
         if self.versioned:
             return EnvNameDeploy(f"{env_name}@{self.lock_version}")
         return EnvNameDeploy(env_name)
+
+    def append_other_input(self, other_input: str) -> None:
+        """Supply an additional "other input" to use when determining lock validity."""
+        self.other_inputs = (*self.other_inputs, other_input)
+        self._update_other_inputs_hash()
+
+    def extend_other_inputs(self, other_inputs: Sequence[str]) -> None:
+        """Supply additional "other inputs" to use when determining lock validity."""
+        self.other_inputs = (*self.other_inputs, *other_inputs)
+        self._update_other_inputs_hash()
 
     def _fail_lock_metadata_query(self, message: str) -> NoReturn:
         req_path = self.locked_requirements_path
@@ -310,7 +323,12 @@ class EnvironmentLock:
             return None
         return cls._hash_reqs(requirements_path.read_text().splitlines())
 
-    def _update_req_hashes(self) -> None:
+    def _update_other_inputs_hash(self) -> None:
+        self._other_inputs_hash = _hash_strings(self.other_inputs)
+
+    def _update_hashes(self) -> None:
+        self._update_other_inputs_hash()
+        self._other_inputs_hash = _hash_strings(self.other_inputs)
         self._lock_input_hash = input_hash = self._hash_reqs(self.declared_requirements)
         if self._hash_req_file(self._lock_input_path) != input_hash:
             # Declared requirements input file is out of date, so locked output is not valid
@@ -370,6 +388,7 @@ class EnvironmentLock:
             not lock_metadata
             or lock_input_hash != lock_metadata.get("lock_input_hash", None)
             or req_hash != lock_metadata.get("requirements_hash", None)
+            or self._other_inputs_hash != lock_metadata.get("other_inputs_hash", None)
         ):
             return None
         return lock_metadata
@@ -424,6 +443,7 @@ class EnvironmentLock:
         lock_metadata = EnvironmentLockMetadata(
             requirements_hash=req_hash,
             lock_input_hash=lock_input_hash,
+            other_inputs_hash=self._other_inputs_hash,
             lock_version=lock_version,
             locked_at=self.locked_at,
         )
@@ -1235,13 +1255,21 @@ class LayerEnvBase(ABC):
             self.dynlib_path = self.env_path / "share" / "venv" / "dynlib"
         self.env_lock = EnvironmentLock(
             self.requirements_path,
-            self.env_spec.requirements,
+            (*self.env_spec.requirements,),
+            self._get_common_lock_inputs(),
             self.env_spec.versioned,
         )
         # Ensure symlinks in the environment paths aren't inadvertently resolved
         assert self.pylib_path.relative_to(self.env_path)
         assert self.executables_path.relative_to(self.env_path)
         assert self.dynlib_path.relative_to(self.env_path)
+
+    def _get_common_lock_inputs(self) -> tuple[str, ...]:
+        return (
+            f"env_name={self.env_name}",
+            f"py_version={'.'.join(self.py_version.split('.')[:2])}",
+            f"is_versioned_layer={self.env_spec.versioned}",
+        )
 
     @property
     def env_spec(self) -> LayerSpecBase:
@@ -1828,6 +1856,7 @@ class LayeredEnvBase(LayerEnvBase):
         if self.linked_constraints_paths:
             self._fail_build("Layered environment base runtime already linked")
         self.linked_constraints_paths[:] = [runtime.requirements_path]
+        self.env_lock.append_other_input(runtime.env_name)
         print(f"Linked {self}")
 
     def link_layered_environments(
@@ -1840,13 +1869,17 @@ class LayeredEnvBase(LayerEnvBase):
             self._fail_build("Failed to add base environment constraints path")
         # The runtime site-packages folder is added here rather than via pyvenv.cfg
         # to ensure it appears in sys.path after the framework site-packages folders
+        fw_env_names: list[str] = []
         fw_envs = self.linked_frameworks
         if fw_envs:
             self._fail_build("Layered application environment already linked")
         for env_spec in self.env_spec.frameworks:
-            env = frameworks[env_spec.name]
+            fw_env_name = env_spec.name
+            fw_env_names.append(fw_env_name)
+            env = frameworks[fw_env_name]
             fw_envs.append(env)
             constraints_paths.append(env.requirements_path)
+        self.env_lock.extend_other_inputs(fw_env_names)
         # Invalidate this environment's lock if any layer it depends on needs locking
         if not self.needs_lock():
             if runtime.needs_lock():

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -417,8 +417,10 @@ class EnvironmentLock:
         # Otherwise wait until the lock metadata is updated after the layer is locked
         return None
 
-    def _get_last_locked_version(self, *, checked=True) -> int | None:
-        lock_metadata = self.load_valid_metadata() if checked else self._load_saved_metadata()
+    def _get_last_locked_version(self, *, checked: bool = True) -> int | None:
+        lock_metadata = (
+            self.load_valid_metadata() if checked else self._load_saved_metadata()
+        )
         if lock_metadata is not None:
             # Unversioned specs are always considered version 1
             return lock_metadata.get("lock_version", 1)

--- a/tests/expected-output-config.toml
+++ b/tests/expected-output-config.toml
@@ -33,4 +33,4 @@ UV_EXCLUDE_NEWER="2025-04-27 00:00:00+00:00"
 # Metadata updates can also be requested when the
 # launch module content in the sample project changes
 
-# Last requested update: add package summary review files
+# Last requested update: updates to layer lock invalidation

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-client.json
@@ -3,7 +3,7 @@
   "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "cd3fc0aca3170cae91891a4b4a40578332068e8268e503985b40435e0703a7d6"
+    "sha256": "1b5748e30bc2c8e8dc995ba7dd6615c8520322895039846d388cbf95304a05a4"
   },
   "archive_name": "app-scipy-client.tar.xz",
   "archive_size": 3700,
@@ -11,7 +11,7 @@
   "install_target": "app-scipy-client",
   "layer_name": "app-scipy-client",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:52.020571+00:00",
+  "locked_at": "2025-05-06T13:02:26.857280+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [
     "framework-scipy@1",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-import.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-scipy-import.json
@@ -3,7 +3,7 @@
   "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "6488cf9a47ec5dba7b5a86b055efb66dd35db62299c51efeb19bf36ab9a40b8b"
+    "sha256": "873ba3fde061d3b5fca22cb45ce1d650ef2e92bbeb560ef4b9815b3700b92a1b"
   },
   "archive_name": "app-scipy-import@1.tar.xz",
   "archive_size": 3600,
@@ -11,7 +11,7 @@
   "install_target": "app-scipy-import@1",
   "layer_name": "app-scipy-import",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.989572+00:00",
+  "locked_at": "2025-05-06T13:02:26.827280+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [
     "framework-scipy@1"

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-sklearn-import.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/app-sklearn-import.json
@@ -3,15 +3,15 @@
   "app_launch_module_hash": "sha256:f48aeede7d02ae34856f0149bb15b3cd4bebd3a82911cfd4e2e1c2639b8cd53c",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "31dc04d2dbe36678c6b00e3f34af9db475b7e5d480597fab33f20d09946d2b6a"
+    "sha256": "2a4472d350102d3e11dc752d544f45b04c31f7ca5aee9990b444631e3f5cfa02"
   },
   "archive_name": "app-sklearn-import.tar.xz",
-  "archive_size": 3600,
+  "archive_size": 3604,
   "bound_to_implementation": false,
   "install_target": "app-sklearn-import",
   "layer_name": "app-sklearn-import",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:52.052571+00:00",
+  "locked_at": "2025-05-06T13:02:26.887280+00:00",
   "python_implementation": "cpython@3.12.9",
   "required_layers": [
     "framework-sklearn"

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.11.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "82b262105bf8069a208517ab10b8b1eebea6649f3303082dd440831e651d492e"
+    "sha256": "bbfd47cda44889d693d9a0d93e15001f355cbb8cae626312fd2555a4863c4dbb"
   },
   "archive_name": "cpython-3.11.tar.xz",
-  "archive_size": 29799880,
+  "archive_size": 29801664,
   "bound_to_implementation": true,
   "install_target": "cpython-3.11",
   "layer_name": "cpython-3.11",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.799572+00:00",
+  "locked_at": "2025-05-06T13:02:25.197280+00:00",
   "python_implementation": "cpython@3.11.11",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
   "runtime_layer": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/cpython-3.12.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "1561014bae7860ce9c914572a0d7c897b357d1c29b99558e2effece580a33b22"
+    "sha256": "df013a481b459b0d29f5ec5c1bb22b3002cb26485584e5fd8f02d1b5b05ffe9c"
   },
   "archive_name": "cpython-3.12.tar.xz",
-  "archive_size": 42597048,
+  "archive_size": 42522188,
   "bound_to_implementation": true,
   "install_target": "cpython-3.12",
   "layer_name": "cpython-3.12",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.868572+00:00",
+  "locked_at": "2025-05-06T13:02:25.547280+00:00",
   "python_implementation": "cpython@3.12.9",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
   "runtime_layer": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-http-client.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "cd528cff61e3cf445a7f46faef39465fd3cd5a91888e5c5a5cb5218a3844b901"
+    "sha256": "9dd88b1a51170d404bec09ff842a7a31cdd0f57346ad8652dd2634a181c9aedf"
   },
   "archive_name": "framework-http-client.tar.xz",
-  "archive_size": 351916,
+  "archive_size": 351612,
   "bound_to_implementation": false,
   "install_target": "framework-http-client",
   "layer_name": "framework-http-client",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.959572+00:00",
+  "locked_at": "2025-05-06T13:02:26.807280+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [],
   "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-scipy.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "704e4cc558fad0da12a2d4c0f4bbb5397335857a505966dbc655673568a1bc3a"
+    "sha256": "4aa18850bf0cddda837d7f72dcad82be9b67913baed830d467d34f3a2d176c62"
   },
   "archive_name": "framework-scipy@1.tar.xz",
-  "archive_size": 23965080,
+  "archive_size": 23961468,
   "bound_to_implementation": false,
   "install_target": "framework-scipy@1",
   "layer_name": "framework-scipy",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.896572+00:00",
+  "locked_at": "2025-05-06T13:02:25.857280+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [],
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",

--- a/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/env_metadata/framework-sklearn.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "4fc71a8bc1a6cb1aa493333030acfa23d6836100f0911f3ac53bf0054a4544e1"
+    "sha256": "d20ad8ebc4e0e1cf96bbef0f1f114bc71f581e7ba218011f97bf2e3d1684dc6e"
   },
   "archive_name": "framework-sklearn.tar.xz",
-  "archive_size": 30372816,
+  "archive_size": 30379352,
   "bound_to_implementation": false,
   "install_target": "framework-sklearn",
   "layer_name": "framework-sklearn",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.928572+00:00",
+  "locked_at": "2025-05-06T13:02:26.717280+00:00",
   "python_implementation": "cpython@3.12.9",
   "required_layers": [],
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",

--- a/tests/sample_project/expected_manifests/linux_x86_64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/linux_x86_64/venvstacks.json
@@ -6,7 +6,7 @@
         "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "6488cf9a47ec5dba7b5a86b055efb66dd35db62299c51efeb19bf36ab9a40b8b"
+          "sha256": "873ba3fde061d3b5fca22cb45ce1d650ef2e92bbeb560ef4b9815b3700b92a1b"
         },
         "archive_name": "app-scipy-import@1.tar.xz",
         "archive_size": 3600,
@@ -14,7 +14,7 @@
         "install_target": "app-scipy-import@1",
         "layer_name": "app-scipy-import",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:51.989572+00:00",
+        "locked_at": "2025-05-06T13:02:26.827280+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [
           "framework-scipy@1"
@@ -28,7 +28,7 @@
         "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "cd3fc0aca3170cae91891a4b4a40578332068e8268e503985b40435e0703a7d6"
+          "sha256": "1b5748e30bc2c8e8dc995ba7dd6615c8520322895039846d388cbf95304a05a4"
         },
         "archive_name": "app-scipy-client.tar.xz",
         "archive_size": 3700,
@@ -36,7 +36,7 @@
         "install_target": "app-scipy-client",
         "layer_name": "app-scipy-client",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:52.020571+00:00",
+        "locked_at": "2025-05-06T13:02:26.857280+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [
           "framework-scipy@1",
@@ -51,15 +51,15 @@
         "app_launch_module_hash": "sha256:f48aeede7d02ae34856f0149bb15b3cd4bebd3a82911cfd4e2e1c2639b8cd53c",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "31dc04d2dbe36678c6b00e3f34af9db475b7e5d480597fab33f20d09946d2b6a"
+          "sha256": "2a4472d350102d3e11dc752d544f45b04c31f7ca5aee9990b444631e3f5cfa02"
         },
         "archive_name": "app-sklearn-import.tar.xz",
-        "archive_size": 3600,
+        "archive_size": 3604,
         "bound_to_implementation": false,
         "install_target": "app-sklearn-import",
         "layer_name": "app-sklearn-import",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:52.052571+00:00",
+        "locked_at": "2025-05-06T13:02:26.887280+00:00",
         "python_implementation": "cpython@3.12.9",
         "required_layers": [
           "framework-sklearn"
@@ -73,15 +73,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "704e4cc558fad0da12a2d4c0f4bbb5397335857a505966dbc655673568a1bc3a"
+          "sha256": "4aa18850bf0cddda837d7f72dcad82be9b67913baed830d467d34f3a2d176c62"
         },
         "archive_name": "framework-scipy@1.tar.xz",
-        "archive_size": 23965080,
+        "archive_size": 23961468,
         "bound_to_implementation": false,
         "install_target": "framework-scipy@1",
         "layer_name": "framework-scipy",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:51.896572+00:00",
+        "locked_at": "2025-05-06T13:02:25.857280+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [],
         "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
@@ -91,15 +91,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "4fc71a8bc1a6cb1aa493333030acfa23d6836100f0911f3ac53bf0054a4544e1"
+          "sha256": "d20ad8ebc4e0e1cf96bbef0f1f114bc71f581e7ba218011f97bf2e3d1684dc6e"
         },
         "archive_name": "framework-sklearn.tar.xz",
-        "archive_size": 30372816,
+        "archive_size": 30379352,
         "bound_to_implementation": false,
         "install_target": "framework-sklearn",
         "layer_name": "framework-sklearn",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:51.928572+00:00",
+        "locked_at": "2025-05-06T13:02:26.717280+00:00",
         "python_implementation": "cpython@3.12.9",
         "required_layers": [],
         "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
@@ -109,15 +109,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "cd528cff61e3cf445a7f46faef39465fd3cd5a91888e5c5a5cb5218a3844b901"
+          "sha256": "9dd88b1a51170d404bec09ff842a7a31cdd0f57346ad8652dd2634a181c9aedf"
         },
         "archive_name": "framework-http-client.tar.xz",
-        "archive_size": 351916,
+        "archive_size": 351612,
         "bound_to_implementation": false,
         "install_target": "framework-http-client",
         "layer_name": "framework-http-client",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:51.959572+00:00",
+        "locked_at": "2025-05-06T13:02:26.807280+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [],
         "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",
@@ -129,15 +129,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "82b262105bf8069a208517ab10b8b1eebea6649f3303082dd440831e651d492e"
+          "sha256": "bbfd47cda44889d693d9a0d93e15001f355cbb8cae626312fd2555a4863c4dbb"
         },
         "archive_name": "cpython-3.11.tar.xz",
-        "archive_size": 29799880,
+        "archive_size": 29801664,
         "bound_to_implementation": true,
         "install_target": "cpython-3.11",
         "layer_name": "cpython-3.11",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:51.799572+00:00",
+        "locked_at": "2025-05-06T13:02:25.197280+00:00",
         "python_implementation": "cpython@3.11.11",
         "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
         "runtime_layer": "cpython-3.11",
@@ -146,15 +146,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "1561014bae7860ce9c914572a0d7c897b357d1c29b99558e2effece580a33b22"
+          "sha256": "df013a481b459b0d29f5ec5c1bb22b3002cb26485584e5fd8f02d1b5b05ffe9c"
         },
         "archive_name": "cpython-3.12.tar.xz",
-        "archive_size": 42597048,
+        "archive_size": 42522188,
         "bound_to_implementation": true,
         "install_target": "cpython-3.12",
         "layer_name": "cpython-3.12",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:22:51.868572+00:00",
+        "locked_at": "2025-05-06T13:02:25.547280+00:00",
         "python_implementation": "cpython@3.12.9",
         "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
         "runtime_layer": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-client.json
@@ -3,7 +3,7 @@
   "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "933e14cbfa12730933b46667b99dcfbf3918158d1d57fc946338e29684e99bde"
+    "sha256": "15a713aaf849bf81f635a4f4994c090efe10c6d2f7842e9c850fd89a6ba255c4"
   },
   "archive_name": "app-scipy-client.tar.xz",
   "archive_size": 3680,
@@ -11,10 +11,10 @@
   "install_target": "app-scipy-client",
   "layer_name": "app-scipy-client",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.857670+00:00",
+  "locked_at": "2025-05-06T14:22:40.830169+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [
-    "framework-scipy@1",
+    "framework-scipy@2",
     "framework-http-client"
   ],
   "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-import.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/app-scipy-import.json
@@ -3,18 +3,18 @@
   "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "1435b592016620703c29bb68bfb82fb46690334461e0fd52280e5d425acd48a7"
+    "sha256": "52cae44b1604d24ba3acbf74cbb6aadc3c3febd5e62a0d776d9bcbf73a79cbe3"
   },
-  "archive_name": "app-scipy-import@1.tar.xz",
-  "archive_size": 3576,
+  "archive_name": "app-scipy-import@2.tar.xz",
+  "archive_size": 3572,
   "bound_to_implementation": false,
-  "install_target": "app-scipy-import@1",
+  "install_target": "app-scipy-import@2",
   "layer_name": "app-scipy-import",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.827179+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:22:40.798487+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [
-    "framework-scipy@1"
+    "framework-scipy@2"
   ],
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
   "runtime_layer": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.11.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "1cb42c4340babc6c9a080843a05752c19dfb6f891bb2496b5e89b0a002c61b1d"
+    "sha256": "336d71c2cf72a6a76df44a4ec80840e2c9c81ea73a5bb04ec8a0e3e9293dfa39"
   },
   "archive_name": "cpython-3.11.tar.xz",
-  "archive_size": 15033884,
+  "archive_size": 15032724,
   "bound_to_implementation": true,
   "install_target": "cpython-3.11",
   "layer_name": "cpython-3.11",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.657165+00:00",
+  "locked_at": "2025-05-06T14:22:40.424219+00:00",
   "python_implementation": "cpython@3.11.11",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
   "runtime_layer": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/cpython-3.12.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "e911a46cc23859cb542f81d7e15a00fef59077ed85398da9be36250ccae6f1fa"
+    "sha256": "ce4d37d997dd97190521817215694eab9f51d2f56f74ec27c74c8ae0a891b390"
   },
   "archive_name": "cpython-3.12.tar.xz",
-  "archive_size": 13668816,
+  "archive_size": 13669028,
   "bound_to_implementation": true,
   "install_target": "cpython-3.12",
   "layer_name": "cpython-3.12",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.707322+00:00",
+  "locked_at": "2025-05-06T14:22:40.497966+00:00",
   "python_implementation": "cpython@3.12.9",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
   "runtime_layer": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-http-client.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "e24377dc231bbe7fa761e07bc799902a0af867d1a4f07717d0726442606dc3d4"
+    "sha256": "a866d59f26e91bd0140bbcf91f8430f52ad5554cd64e1bb1122e7308bf02b587"
   },
   "archive_name": "framework-http-client.tar.xz",
-  "archive_size": 351784,
+  "archive_size": 351584,
   "bound_to_implementation": false,
   "install_target": "framework-http-client",
   "layer_name": "framework-http-client",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.797668+00:00",
+  "locked_at": "2025-05-06T14:22:40.770077+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [],
   "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-scipy.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "541a47b0fdb4b9bc75604dc810807c9226362d138e4a02c5eaafd08ee406a872"
+    "sha256": "fdf064d18a5106bcf15abbd4b7299faf1f0fcaf4ed03c222339456a781683da4"
   },
-  "archive_name": "framework-scipy@1.tar.xz",
-  "archive_size": 15081756,
+  "archive_name": "framework-scipy@2.tar.xz",
+  "archive_size": 15075004,
   "bound_to_implementation": false,
-  "install_target": "framework-scipy@1",
+  "install_target": "framework-scipy@2",
   "layer_name": "framework-scipy",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.736986+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:22:40.574726+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [],
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",

--- a/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/env_metadata/framework-sklearn.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "93c50d129dda4f2f8ad8906931f30338d9474b27aa56fe840d4540ddccc7460b"
+    "sha256": "b1b1f5fabacf71aa407d338e2f72703c22da1bd3f563506f768e2d005527af2c"
   },
   "archive_name": "framework-sklearn.tar.xz",
-  "archive_size": 20683024,
+  "archive_size": 20691252,
   "bound_to_implementation": false,
   "install_target": "framework-sklearn",
   "layer_name": "framework-sklearn",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.768636+00:00",
+  "locked_at": "2025-05-06T14:22:40.682717+00:00",
   "python_implementation": "cpython@3.12.9",
   "required_layers": [],
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",

--- a/tests/sample_project/expected_manifests/macosx_arm64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/macosx_arm64/venvstacks.json
@@ -6,18 +6,18 @@
         "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "1435b592016620703c29bb68bfb82fb46690334461e0fd52280e5d425acd48a7"
+          "sha256": "52cae44b1604d24ba3acbf74cbb6aadc3c3febd5e62a0d776d9bcbf73a79cbe3"
         },
-        "archive_name": "app-scipy-import@1.tar.xz",
-        "archive_size": 3576,
+        "archive_name": "app-scipy-import@2.tar.xz",
+        "archive_size": 3572,
         "bound_to_implementation": false,
-        "install_target": "app-scipy-import@1",
+        "install_target": "app-scipy-import@2",
         "layer_name": "app-scipy-import",
-        "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.827179+00:00",
+        "lock_version": 2,
+        "locked_at": "2025-05-06T14:22:40.798487+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [
-          "framework-scipy@1"
+          "framework-scipy@2"
         ],
         "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
         "runtime_layer": "cpython-3.11",
@@ -28,7 +28,7 @@
         "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "933e14cbfa12730933b46667b99dcfbf3918158d1d57fc946338e29684e99bde"
+          "sha256": "15a713aaf849bf81f635a4f4994c090efe10c6d2f7842e9c850fd89a6ba255c4"
         },
         "archive_name": "app-scipy-client.tar.xz",
         "archive_size": 3680,
@@ -36,10 +36,10 @@
         "install_target": "app-scipy-client",
         "layer_name": "app-scipy-client",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.857670+00:00",
+        "locked_at": "2025-05-06T14:22:40.830169+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [
-          "framework-scipy@1",
+          "framework-scipy@2",
           "framework-http-client"
         ],
         "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",
@@ -51,15 +51,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "541a47b0fdb4b9bc75604dc810807c9226362d138e4a02c5eaafd08ee406a872"
+          "sha256": "fdf064d18a5106bcf15abbd4b7299faf1f0fcaf4ed03c222339456a781683da4"
         },
-        "archive_name": "framework-scipy@1.tar.xz",
-        "archive_size": 15081756,
+        "archive_name": "framework-scipy@2.tar.xz",
+        "archive_size": 15075004,
         "bound_to_implementation": false,
-        "install_target": "framework-scipy@1",
+        "install_target": "framework-scipy@2",
         "layer_name": "framework-scipy",
-        "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.736986+00:00",
+        "lock_version": 2,
+        "locked_at": "2025-05-06T14:22:40.574726+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [],
         "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
@@ -69,15 +69,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "93c50d129dda4f2f8ad8906931f30338d9474b27aa56fe840d4540ddccc7460b"
+          "sha256": "b1b1f5fabacf71aa407d338e2f72703c22da1bd3f563506f768e2d005527af2c"
         },
         "archive_name": "framework-sklearn.tar.xz",
-        "archive_size": 20683024,
+        "archive_size": 20691252,
         "bound_to_implementation": false,
         "install_target": "framework-sklearn",
         "layer_name": "framework-sklearn",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.768636+00:00",
+        "locked_at": "2025-05-06T14:22:40.682717+00:00",
         "python_implementation": "cpython@3.12.9",
         "required_layers": [],
         "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
@@ -87,15 +87,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "e24377dc231bbe7fa761e07bc799902a0af867d1a4f07717d0726442606dc3d4"
+          "sha256": "a866d59f26e91bd0140bbcf91f8430f52ad5554cd64e1bb1122e7308bf02b587"
         },
         "archive_name": "framework-http-client.tar.xz",
-        "archive_size": 351784,
+        "archive_size": 351584,
         "bound_to_implementation": false,
         "install_target": "framework-http-client",
         "layer_name": "framework-http-client",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.797668+00:00",
+        "locked_at": "2025-05-06T14:22:40.770077+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [],
         "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",
@@ -107,15 +107,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "1cb42c4340babc6c9a080843a05752c19dfb6f891bb2496b5e89b0a002c61b1d"
+          "sha256": "336d71c2cf72a6a76df44a4ec80840e2c9c81ea73a5bb04ec8a0e3e9293dfa39"
         },
         "archive_name": "cpython-3.11.tar.xz",
-        "archive_size": 15033884,
+        "archive_size": 15032724,
         "bound_to_implementation": true,
         "install_target": "cpython-3.11",
         "layer_name": "cpython-3.11",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.657165+00:00",
+        "locked_at": "2025-05-06T14:22:40.424219+00:00",
         "python_implementation": "cpython@3.11.11",
         "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
         "runtime_layer": "cpython-3.11",
@@ -124,15 +124,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "e911a46cc23859cb542f81d7e15a00fef59077ed85398da9be36250ccae6f1fa"
+          "sha256": "ce4d37d997dd97190521817215694eab9f51d2f56f74ec27c74c8ae0a891b390"
         },
         "archive_name": "cpython-3.12.tar.xz",
-        "archive_size": 13668816,
+        "archive_size": 13669028,
         "bound_to_implementation": true,
         "install_target": "cpython-3.12",
         "layer_name": "cpython-3.12",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:11.707322+00:00",
+        "locked_at": "2025-05-06T14:22:40.497966+00:00",
         "python_implementation": "cpython@3.12.9",
         "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
         "runtime_layer": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-client.json
@@ -3,18 +3,18 @@
   "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "280e1a3c06cd391d27582c159aa777754527addd5570cbdc467f841368ed4035"
+    "sha256": "21318f6f9485324c7c373e71f7504b869cd9e5803755d05ba3b0c03d2a7db70a"
   },
   "archive_name": "app-scipy-client.zip",
-  "archive_size": 257817,
+  "archive_size": 257819,
   "bound_to_implementation": true,
   "install_target": "app-scipy-client",
   "layer_name": "app-scipy-client",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:18.247062+00:00",
+  "locked_at": "2025-05-06T14:23:53.888940+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [
-    "framework-scipy@1",
+    "framework-scipy@2",
     "framework-http-client"
   ],
   "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-import.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/app-scipy-import.json
@@ -3,18 +3,18 @@
   "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "ceaabb3ec3cccb1d1dc30b66750dd77577c08a143486fbb37405882bf78df916"
+    "sha256": "93305d0a4c76951c12f68427fb51c0e80f500009175844bb8be7a540d2b4b42f"
   },
-  "archive_name": "app-scipy-import@1.zip",
-  "archive_size": 257377,
+  "archive_name": "app-scipy-import@2.zip",
+  "archive_size": 257378,
   "bound_to_implementation": true,
-  "install_target": "app-scipy-import@1",
+  "install_target": "app-scipy-import@2",
   "layer_name": "app-scipy-import",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:18.165045+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:23:53.812813+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [
-    "framework-scipy@1"
+    "framework-scipy@2"
   ],
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
   "runtime_layer": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.11.json
@@ -1,7 +1,7 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "3a93382455cf63aba165963f36df281898a6bd5f8ed18c9fc89d79c546cf3686"
+    "sha256": "8d1a3cf0743730830fe3bbee823d28c7c248df818dc33c2debe477c84780ce51"
   },
   "archive_name": "cpython-3.11.zip",
   "archive_size": 50101263,
@@ -9,7 +9,7 @@
   "install_target": "cpython-3.11",
   "layer_name": "cpython-3.11",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.593403+00:00",
+  "locked_at": "2025-05-06T14:23:53.304519+00:00",
   "python_implementation": "cpython@3.11.11",
   "requirements_hash": "sha256:73bee58127351c581c2599ee62f96d71b5fbe8f5a85bf0b7e5f9230d6a2024d3",
   "runtime_layer": "cpython-3.11",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/cpython-3.12.json
@@ -1,7 +1,7 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "bf41ccbc7e2201fe2f78193e823bb94c8ce5ba9c16c82682fdf6420677734c75"
+    "sha256": "22925c17dcd0813310270b5eda3a363044cbff1b0d5a76947529511c9e2b9538"
   },
   "archive_name": "cpython-3.12.zip",
   "archive_size": 49923263,
@@ -9,7 +9,7 @@
   "install_target": "cpython-3.12",
   "layer_name": "cpython-3.12",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.756486+00:00",
+  "locked_at": "2025-05-06T14:23:53.458220+00:00",
   "python_implementation": "cpython@3.12.9",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
   "runtime_layer": "cpython-3.12",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-http-client.json
@@ -1,7 +1,7 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "e21ae2548d40f65f96332e0e288c48fe700126d449e192056a1b2a0123ef7cba"
+    "sha256": "20df11466d08bfae8a115491728d0760b1cab5997ddee4f34567cb388bd11336"
   },
   "archive_name": "framework-http-client.zip",
   "archive_size": 800074,
@@ -9,7 +9,7 @@
   "install_target": "framework-http-client",
   "layer_name": "framework-http-client",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:18.093384+00:00",
+  "locked_at": "2025-05-06T14:23:53.734827+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [],
   "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-scipy.json
@@ -1,15 +1,15 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "1e3a2a8946b571a24f286aa41d206c9634064d0504610aab907df90ca850e391"
+    "sha256": "06e80a46baef9245014f11630ea903b7bcf820b6f4ef5589e2f5422ef2bc4be8"
   },
-  "archive_name": "framework-scipy@1.zip",
+  "archive_name": "framework-scipy@2.zip",
   "archive_size": 45087925,
   "bound_to_implementation": true,
-  "install_target": "framework-scipy@1",
+  "install_target": "framework-scipy@2",
   "layer_name": "framework-scipy",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.869245+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:23:53.550281+00:00",
   "python_implementation": "cpython@3.11.11",
   "required_layers": [],
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",

--- a/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/win_amd64/env_metadata/framework-sklearn.json
@@ -1,7 +1,7 @@
 {
   "archive_build": 1,
   "archive_hashes": {
-    "sha256": "3b2e6f8f7cb42c9dc52a2a3d56ab371044983059dc47a9a3be91071e1e8467ca"
+    "sha256": "cf1f2d49a2ddb9f1f0fea2b0eb0a7239acc753c758269dd4457b9f37959d0768"
   },
   "archive_name": "framework-sklearn.zip",
   "archive_size": 56188836,
@@ -9,7 +9,7 @@
   "install_target": "framework-sklearn",
   "layer_name": "framework-sklearn",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.981010+00:00",
+  "locked_at": "2025-05-06T14:23:53.642461+00:00",
   "python_implementation": "cpython@3.12.9",
   "required_layers": [],
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",

--- a/tests/sample_project/expected_manifests/win_amd64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/win_amd64/venvstacks.json
@@ -6,18 +6,18 @@
         "app_launch_module_hash": "sha256:3970f360501594e9603c2799861aba17e5e7b4f6c37a3dc0ba59de42f07ba998",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "ceaabb3ec3cccb1d1dc30b66750dd77577c08a143486fbb37405882bf78df916"
+          "sha256": "93305d0a4c76951c12f68427fb51c0e80f500009175844bb8be7a540d2b4b42f"
         },
-        "archive_name": "app-scipy-import@1.zip",
-        "archive_size": 257377,
+        "archive_name": "app-scipy-import@2.zip",
+        "archive_size": 257378,
         "bound_to_implementation": true,
-        "install_target": "app-scipy-import@1",
+        "install_target": "app-scipy-import@2",
         "layer_name": "app-scipy-import",
-        "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:18.165045+00:00",
+        "lock_version": 2,
+        "locked_at": "2025-05-06T14:23:53.812813+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [
-          "framework-scipy@1"
+          "framework-scipy@2"
         ],
         "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
         "runtime_layer": "cpython-3.11",
@@ -28,18 +28,18 @@
         "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "280e1a3c06cd391d27582c159aa777754527addd5570cbdc467f841368ed4035"
+          "sha256": "21318f6f9485324c7c373e71f7504b869cd9e5803755d05ba3b0c03d2a7db70a"
         },
         "archive_name": "app-scipy-client.zip",
-        "archive_size": 257817,
+        "archive_size": 257819,
         "bound_to_implementation": true,
         "install_target": "app-scipy-client",
         "layer_name": "app-scipy-client",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:18.247062+00:00",
+        "locked_at": "2025-05-06T14:23:53.888940+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [
-          "framework-scipy@1",
+          "framework-scipy@2",
           "framework-http-client"
         ],
         "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",
@@ -51,15 +51,15 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "1e3a2a8946b571a24f286aa41d206c9634064d0504610aab907df90ca850e391"
+          "sha256": "06e80a46baef9245014f11630ea903b7bcf820b6f4ef5589e2f5422ef2bc4be8"
         },
-        "archive_name": "framework-scipy@1.zip",
+        "archive_name": "framework-scipy@2.zip",
         "archive_size": 45087925,
         "bound_to_implementation": true,
-        "install_target": "framework-scipy@1",
+        "install_target": "framework-scipy@2",
         "layer_name": "framework-scipy",
-        "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:17.869245+00:00",
+        "lock_version": 2,
+        "locked_at": "2025-05-06T14:23:53.550281+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [],
         "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
@@ -69,7 +69,7 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "3b2e6f8f7cb42c9dc52a2a3d56ab371044983059dc47a9a3be91071e1e8467ca"
+          "sha256": "cf1f2d49a2ddb9f1f0fea2b0eb0a7239acc753c758269dd4457b9f37959d0768"
         },
         "archive_name": "framework-sklearn.zip",
         "archive_size": 56188836,
@@ -77,7 +77,7 @@
         "install_target": "framework-sklearn",
         "layer_name": "framework-sklearn",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:17.981010+00:00",
+        "locked_at": "2025-05-06T14:23:53.642461+00:00",
         "python_implementation": "cpython@3.12.9",
         "required_layers": [],
         "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
@@ -87,7 +87,7 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "e21ae2548d40f65f96332e0e288c48fe700126d449e192056a1b2a0123ef7cba"
+          "sha256": "20df11466d08bfae8a115491728d0760b1cab5997ddee4f34567cb388bd11336"
         },
         "archive_name": "framework-http-client.zip",
         "archive_size": 800074,
@@ -95,7 +95,7 @@
         "install_target": "framework-http-client",
         "layer_name": "framework-http-client",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:18.093384+00:00",
+        "locked_at": "2025-05-06T14:23:53.734827+00:00",
         "python_implementation": "cpython@3.11.11",
         "required_layers": [],
         "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",
@@ -107,7 +107,7 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "3a93382455cf63aba165963f36df281898a6bd5f8ed18c9fc89d79c546cf3686"
+          "sha256": "8d1a3cf0743730830fe3bbee823d28c7c248df818dc33c2debe477c84780ce51"
         },
         "archive_name": "cpython-3.11.zip",
         "archive_size": 50101263,
@@ -115,7 +115,7 @@
         "install_target": "cpython-3.11",
         "layer_name": "cpython-3.11",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:17.593403+00:00",
+        "locked_at": "2025-05-06T14:23:53.304519+00:00",
         "python_implementation": "cpython@3.11.11",
         "requirements_hash": "sha256:73bee58127351c581c2599ee62f96d71b5fbe8f5a85bf0b7e5f9230d6a2024d3",
         "runtime_layer": "cpython-3.11",
@@ -124,7 +124,7 @@
       {
         "archive_build": 1,
         "archive_hashes": {
-          "sha256": "bf41ccbc7e2201fe2f78193e823bb94c8ce5ba9c16c82682fdf6420677734c75"
+          "sha256": "22925c17dcd0813310270b5eda3a363044cbff1b0d5a76947529511c9e2b9538"
         },
         "archive_name": "cpython-3.12.zip",
         "archive_size": 49923263,
@@ -132,7 +132,7 @@
         "install_target": "cpython-3.12",
         "layer_name": "cpython-3.12",
         "lock_version": 1,
-        "locked_at": "2025-05-01T15:24:17.756486+00:00",
+        "locked_at": "2025-05-06T14:23:53.458220+00:00",
         "python_implementation": "cpython@3.12.9",
         "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
         "runtime_layer": "cpython-3.12",

--- a/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:bd49f0f62084fbbb8e91811047978cf8f793339080131bb525e44e281bb3e582",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:52.020571+00:00",
+  "locked_at": "2025-05-06T13:02:26.857280+00:00",
+  "other_inputs_hash": "sha256:7b85c8d0736840c957a7e1a1c4360480b3c05334fe7cf0cede629f4fed59a919",
   "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea"
 }

--- a/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:bd49f0f62084fbbb8e91811047978cf8f793339080131bb525e44e281bb3e582",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.857670+00:00",
+  "locked_at": "2025-05-06T14:22:40.830169+00:00",
+  "other_inputs_hash": "sha256:7b85c8d0736840c957a7e1a1c4360480b3c05334fe7cf0cede629f4fed59a919",
   "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea"
 }

--- a/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-win_amd64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:bd49f0f62084fbbb8e91811047978cf8f793339080131bb525e44e281bb3e582",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:18.247062+00:00",
+  "locked_at": "2025-05-06T14:23:53.888940+00:00",
+  "other_inputs_hash": "sha256:7b85c8d0736840c957a7e1a1c4360480b3c05334fe7cf0cede629f4fed59a919",
   "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea"
 }

--- a/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.989572+00:00",
+  "locked_at": "2025-05-06T13:02:26.827280+00:00",
+  "other_inputs_hash": "sha256:58a305c46057451f6627e87609a9d6676eea774fbd3182479c92e74a5f1899d5",
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
 }

--- a/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.827179+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:22:40.798487+00:00",
+  "other_inputs_hash": "sha256:58a305c46057451f6627e87609a9d6676eea774fbd3182479c92e74a5f1899d5",
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
 }

--- a/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-win_amd64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:18.165045+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:23:53.812813+00:00",
+  "other_inputs_hash": "sha256:58a305c46057451f6627e87609a9d6676eea774fbd3182479c92e74a5f1899d5",
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
 }

--- a/tests/sample_project/requirements/app-sklearn-import/requirements-app-sklearn-import-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/app-sklearn-import/requirements-app-sklearn-import-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:52.052571+00:00",
+  "locked_at": "2025-05-06T13:02:26.887280+00:00",
+  "other_inputs_hash": "sha256:369e2c4f38b698614a7b95c73a439379f1da36474d1a247bbccfc21cb50d619f",
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
 }

--- a/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:5903fe36dad435d8fe1a0ae3e5b3ffe70377c4f958695b087a67169417edd793",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.799572+00:00",
+  "locked_at": "2025-05-06T13:02:25.197280+00:00",
+  "other_inputs_hash": "sha256:ba2a5dacf6d1a152fc67bbbf13b64e9402fdefcfd9f5ac1b4cf4c8cb5d45ab66",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
 }

--- a/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:5903fe36dad435d8fe1a0ae3e5b3ffe70377c4f958695b087a67169417edd793",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.657165+00:00",
+  "locked_at": "2025-05-06T14:22:40.424219+00:00",
+  "other_inputs_hash": "sha256:ba2a5dacf6d1a152fc67bbbf13b64e9402fdefcfd9f5ac1b4cf4c8cb5d45ab66",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
 }

--- a/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-win_amd64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:5903fe36dad435d8fe1a0ae3e5b3ffe70377c4f958695b087a67169417edd793",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.593403+00:00",
+  "locked_at": "2025-05-06T14:23:53.304519+00:00",
+  "other_inputs_hash": "sha256:ba2a5dacf6d1a152fc67bbbf13b64e9402fdefcfd9f5ac1b4cf4c8cb5d45ab66",
   "requirements_hash": "sha256:73bee58127351c581c2599ee62f96d71b5fbe8f5a85bf0b7e5f9230d6a2024d3"
 }

--- a/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:73dd0baf8e5438da8816254a073ee43b61f8b2cdef6f393e0059cdbc55cb8d9c",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.868572+00:00",
+  "locked_at": "2025-05-06T13:02:25.547280+00:00",
+  "other_inputs_hash": "sha256:8ae5bf71f7991ccceeaa1c2d4256912daf3ab59fdca36bb40a7daa82734e9660",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
 }

--- a/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:73dd0baf8e5438da8816254a073ee43b61f8b2cdef6f393e0059cdbc55cb8d9c",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.707322+00:00",
+  "locked_at": "2025-05-06T14:22:40.497966+00:00",
+  "other_inputs_hash": "sha256:8ae5bf71f7991ccceeaa1c2d4256912daf3ab59fdca36bb40a7daa82734e9660",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
 }

--- a/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-win_amd64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:73dd0baf8e5438da8816254a073ee43b61f8b2cdef6f393e0059cdbc55cb8d9c",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.756486+00:00",
+  "locked_at": "2025-05-06T14:23:53.458220+00:00",
+  "other_inputs_hash": "sha256:8ae5bf71f7991ccceeaa1c2d4256912daf3ab59fdca36bb40a7daa82734e9660",
   "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
 }

--- a/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:88d06260d47079c96afc2b43bf92858aa6a607350a8e8908abf9f055da609d4c",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.959572+00:00",
+  "locked_at": "2025-05-06T13:02:26.807280+00:00",
+  "other_inputs_hash": "sha256:3e698d1f4bc88e3d22e37d35f7b37a0623510eafdfb31444513c8eda7cc48442",
   "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0"
 }

--- a/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:88d06260d47079c96afc2b43bf92858aa6a607350a8e8908abf9f055da609d4c",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.797668+00:00",
+  "locked_at": "2025-05-06T14:22:40.770077+00:00",
+  "other_inputs_hash": "sha256:3e698d1f4bc88e3d22e37d35f7b37a0623510eafdfb31444513c8eda7cc48442",
   "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0"
 }

--- a/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-win_amd64.txt.json
+++ b/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:88d06260d47079c96afc2b43bf92858aa6a607350a8e8908abf9f055da609d4c",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:18.093384+00:00",
+  "locked_at": "2025-05-06T14:23:53.734827+00:00",
+  "other_inputs_hash": "sha256:3e698d1f4bc88e3d22e37d35f7b37a0623510eafdfb31444513c8eda7cc48442",
   "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0"
 }

--- a/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.896572+00:00",
+  "locked_at": "2025-05-06T13:02:25.857280+00:00",
+  "other_inputs_hash": "sha256:d8e20fdac2410eae9eb45c1bc9244f70b8f70e1b27842529250bf36f0d6eb18e",
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
 }

--- a/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.736986+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:22:40.574726+00:00",
+  "other_inputs_hash": "sha256:d8e20fdac2410eae9eb45c1bc9244f70b8f70e1b27842529250bf36f0d6eb18e",
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
 }

--- a/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-win_amd64.txt.json
+++ b/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
-  "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.869245+00:00",
+  "lock_version": 2,
+  "locked_at": "2025-05-06T14:23:53.550281+00:00",
+  "other_inputs_hash": "sha256:d8e20fdac2410eae9eb45c1bc9244f70b8f70e1b27842529250bf36f0d6eb18e",
   "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
 }

--- a/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-linux_x86_64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:22:51.928572+00:00",
+  "locked_at": "2025-05-06T13:02:26.717280+00:00",
+  "other_inputs_hash": "sha256:84ce4ae002c4fdf983ef127b9722a29cff43226203fc5de48edb9848785cb18b",
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
 }

--- a/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-macosx_arm64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:11.768636+00:00",
+  "locked_at": "2025-05-06T14:22:40.682717+00:00",
+  "other_inputs_hash": "sha256:84ce4ae002c4fdf983ef127b9722a29cff43226203fc5de48edb9848785cb18b",
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
 }

--- a/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-win_amd64.txt.json
+++ b/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-win_amd64.txt.json
@@ -1,6 +1,7 @@
 {
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
-  "locked_at": "2025-05-01T15:24:17.981010+00:00",
+  "locked_at": "2025-05-06T14:23:53.642461+00:00",
+  "other_inputs_hash": "sha256:84ce4ae002c4fdf983ef127b9722a29cff43226203fc5de48edb9848785cb18b",
   "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
 }


### PR DESCRIPTION
* Invalidate on major Python version changes
* Invalidate when enabling or disabling implicit layer versioning
* Invalidate when relative paths between deployed layers change

Closes #149