### PR TITLE
Ensure layer input cache files are optional

### DIFF
--- a/docs/changelog.d/20250522_221607_ncoghlan_make_lock_input_files_a_pure_cache.rst
+++ b/docs/changelog.d/20250522_221607_ncoghlan_make_lock_input_files_a_pure_cache.rst
@@ -1,0 +1,5 @@
+Fixed
+-----
+
+- Layer locks are no longer incorrectly marked as invalid solely because the lock
+  input cache files are missing (reported in :issue:`175`).


### PR DESCRIPTION
The updated layer lock invalidation was incorrectly marking layer locks as invalid simply because the lock input cache file was missing, even if the actual requirements input hash hadn't changed.