### PR TITLE
Add --lock-if-needed to build subcommand

### DIFF
--- a/docs/changelog.d/20250603_050408_ncoghlan_only_lock_if_necessary_in_build_subcommand.rst
+++ b/docs/changelog.d/20250603_050408_ncoghlan_only_lock_if_necessary_in_build_subcommand.rst
@@ -1,0 +1,8 @@
+Changed
+-------
+
+- Added a `--lock-if-needed` option to the `build` subcommand that ensures layers
+  are only locked if they don't already have valid transitive environment locks.
+  `--lock` is now a deprecated alias for this option rather than being equivalent
+  to running the `lock` subcommand (proposed in :issue:`196`).
+

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -2954,7 +2954,9 @@ class BuildEnvironment:
             rt_env.create_build_environment(clean=clean)
         return [env.lock_requirements() for env in self.environments_to_lock()]
 
-    def create_environments(self, *, clean: bool = False, lock: bool = False) -> None:
+    def create_environments(
+        self, *, clean: bool = False, lock: bool | None = False
+    ) -> None:
         """Create build environments for specified layers."""
         # Base runtime environments need to exist before dependencies can be locked
         self.build_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
* ensures layers are only locked if they don't have valid environment locks.
* `--lock` is now a deprecated alias for this option rather than being equivalent to running the `lock` subcommand

Closes #196