### PR TITLE
Update and pin workflow action dependencies

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -44,7 +44,8 @@ jobs:
         persist-credentials: false
 
     - name: Build HTML
-      uses: ammaraskar/sphinx-action@8.0.2
+      # https://github.com/ammaraskar/sphinx-action/releases/tag/8.2.3
+      uses: ammaraskar/sphinx-action@54e52bfb642e9b60ea5b6bcb05fe3f74b40d290a
       if: github.event.action != 'closed'
       with:
         docs-folder: "docs/"
@@ -52,7 +53,8 @@ jobs:
         build-command: "sphinx-build -W -b dirhtml . _build"
 
     - name: Deploy preview
-      uses: rossjrw/pr-preview-action@v1
+      # https://github.com/rossjrw/pr-preview-action/releases/tag/v1.6.1
+      uses: rossjrw/pr-preview-action@2fb559e4766555e23d07b73d313fe97c4f8c3cfe
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         source-dir: docs/_build/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,14 +36,16 @@ jobs:
         persist-credentials: false
 
     - name: Build HTML
-      uses: ammaraskar/sphinx-action@8.0.2
+      # https://github.com/ammaraskar/sphinx-action/releases/tag/8.2.3
+      uses: ammaraskar/sphinx-action@54e52bfb642e9b60ea5b6bcb05fe3f74b40d290a
       with:
         docs-folder: "docs/"
         pre-build-command: "sphinx-build -W -b linkcheck . _build"
         build-command: "sphinx-build -W -b dirhtml . _build"
 
     - name: Deploy main docs
-      uses: JamesIves/github-pages-deploy-action@v4
+      # https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.7.3
+      uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8
       if: github.ref == 'refs/heads/main'
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,7 +21,8 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - uses: pandoc/actions/setup@v1
+      # https://github.com/pandoc/actions/releases/tag/v1.1.0
+      - uses: pandoc/actions/setup@54978b2465cef52a89f0e50a71d1397b1c25b469
         with:
           # Control when pandoc is updated
           version: 3.6.4
@@ -30,7 +31,9 @@ jobs:
         with:
           # Control when Python is updated to a new feature release
           python-version: "3.13"
-      - uses: hynek/setup-cached-uv@v2
+
+      # https://github.com/hynek/setup-cached-uv/releases/tag/v2.3.0
+      - uses: hynek/setup-cached-uv@757bedc3f972eb7227a1aa657651f15a8527c817
 
       - name: Create GitHub Release from latest release notes
         run:  |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pdm-project/setup-pdm@v4
+      # https://github.com/pdm-project/setup-pdm/releases/tag/v4.4
+      - uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0
         with:
           python-version: 3.12
           cache: true

--- a/.github/workflows/scan-workflows.yml
+++ b/.github/workflows/scan-workflows.yml
@@ -25,12 +25,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install zizmor
-        run: cargo install zizmor
+      - name: Install the latest version of uv
+        # https://github.com/astral-sh/setup-uv/releases/tag/v6.1.0
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb
 
-      - name: Scan workflows
-        run:
-          zizmor --format=sarif . | tee workflow-scan.sarif
+      - name: Run zizmor 🌈
+        # Only scan this repo's workflows, not anything in submodules
+        run: uvx zizmor==1.8.0 --format sarif .github > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,9 @@ jobs:
         with:
           # Use latest Python, so it understands all syntax.
           python-version: "3.13"
-      - uses: hynek/setup-cached-uv@v2
+
+      # https://github.com/hynek/setup-cached-uv/releases/tag/v2.3.0
+      - uses: hynek/setup-cached-uv@757bedc3f972eb7227a1aa657651f15a8527c817
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Also switches the zizmor scan to use published PyPI releases instead of building from source.