### PR TITLE
Separate version inputs for lock validity checks

### DIFF
--- a/docs/api/stacks/venvstacks.stacks.EnvironmentLock.rst
+++ b/docs/api/stacks/venvstacks.stacks.EnvironmentLock.rst
@@ -11,6 +11,7 @@ venvstacks.stacks.EnvironmentLock
    .. autosummary::
 
       ~EnvironmentLock.append_other_input
+      ~EnvironmentLock.append_version_input
       ~EnvironmentLock.extend_other_inputs
       ~EnvironmentLock.get_deployed_name
       ~EnvironmentLock.invalidate_lock
@@ -30,4 +31,5 @@ venvstacks.stacks.EnvironmentLock
       ~EnvironmentLock.other_inputs
       ~EnvironmentLock.requirements_hash
       ~EnvironmentLock.versioned
+      ~EnvironmentLock.version_inputs
 

--- a/docs/changelog.d/20250606_000755_ncoghlan_separate_version_hash_inputs.rst
+++ b/docs/changelog.d/20250606_000755_ncoghlan_separate_version_hash_inputs.rst
@@ -1,0 +1,7 @@
+Changed
+-------
+
+- Changes to lock inputs that only affect the implicit layer versioning are now
+  tracked separately from changes to the additional inputs that affect the result
+  of the transitive dependency lock generation step. These changes are now ignored
+  for layers that do not use implicit layer versioning (proposed in :issue:`201`).

--- a/docs/file-formats.rst
+++ b/docs/file-formats.rst
@@ -336,11 +336,12 @@ Environment lock metadata files saved alongside the layer's transitively locked 
 
 .. code-block:: python
 
-   requirements_hash: str  # Uses "algorithm:hexdigest" format
-   lock_input_hash: str    # Uses "algorithm:hexdigest" format
-   other_inputs_hash: str  # Uses "algorithm:hexdigest" format
-   lock_version: int       # Auto-incremented from previous lock metadata
-   locked_at: str          # ISO formatted date/time value
+   requirements_hash: str   # Uses "algorithm:hexdigest" format
+   lock_input_hash: str     # Uses "algorithm:hexdigest" format
+   other_inputs_hash: str   # Uses "algorithm:hexdigest" format
+   version_inputs_hash: str # Uses "algorithm:hexdigest" format
+   lock_version: int        # Auto-incremented from previous lock metadata
+   locked_at: str           # ISO formatted date/time value
 
 Note: A future documentation update will cover these ``venvstacks lock`` output files in additional detail.
 

--- a/misc/rehash_test_requirements.py
+++ b/misc/rehash_test_requirements.py
@@ -51,6 +51,7 @@ def _rehash_layer_inputs() -> None:
         env_lock = env_by_name[bundle_name].env_lock
         lock_metadata["lock_input_hash"] = env_lock._lock_input_hash
         lock_metadata["other_inputs_hash"] = env_lock._other_inputs_hash
+        lock_metadata["version_inputs_hash"] = env_lock._version_inputs_hash
         requirements_path = json_path.with_name(json_path.stem)
         requirements_hash = _rehash_req_file(requirements_path)
         lock_metadata["requirements_hash"] = requirements_hash

--- a/tests/expected-output-config.toml
+++ b/tests/expected-output-config.toml
@@ -33,4 +33,4 @@ UV_EXCLUDE_NEWER="2025-04-27 00:00:00+00:00"
 # Metadata updates can also be requested when the
 # launch module content in the sample project changes
 
-# Last requested update: updated base environment links
+# Last requested update: split out version inputs hash

--- a/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:bd49f0f62084fbbb8e91811047978cf8f793339080131bb525e44e281bb3e582",
   "lock_version": 1,
   "locked_at": "2025-05-09T18:45:52.926592+00:00",
-  "other_inputs_hash": "sha256:2f760c224caf6a5def89ca9f2315a8cbf736e2e683007dadc67e413d25f3de37",
-  "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea"
+  "other_inputs_hash": "sha256:8236223df9fad6396ac2c159ac2f36e134d44c414129a609e4494fd33f04e029",
+  "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",
+  "version_inputs_hash": "sha256:6f0b0e68ea3a99b35b288aff9906a4025186b847ad845691da274d883cb5ac3f"
 }

--- a/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:bd49f0f62084fbbb8e91811047978cf8f793339080131bb525e44e281bb3e582",
   "lock_version": 1,
   "locked_at": "2025-05-09T18:45:06.222411+00:00",
-  "other_inputs_hash": "sha256:2f760c224caf6a5def89ca9f2315a8cbf736e2e683007dadc67e413d25f3de37",
-  "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea"
+  "other_inputs_hash": "sha256:8236223df9fad6396ac2c159ac2f36e134d44c414129a609e4494fd33f04e029",
+  "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",
+  "version_inputs_hash": "sha256:6f0b0e68ea3a99b35b288aff9906a4025186b847ad845691da274d883cb5ac3f"
 }

--- a/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-win_amd64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-client/requirements-app-scipy-client-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:bd49f0f62084fbbb8e91811047978cf8f793339080131bb525e44e281bb3e582",
   "lock_version": 1,
   "locked_at": "2025-05-09T18:48:13.688078+00:00",
-  "other_inputs_hash": "sha256:2f760c224caf6a5def89ca9f2315a8cbf736e2e683007dadc67e413d25f3de37",
-  "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea"
+  "other_inputs_hash": "sha256:8236223df9fad6396ac2c159ac2f36e134d44c414129a609e4494fd33f04e029",
+  "requirements_hash": "sha256:378b061db2a736674291cf3b81337b85ffb64c1bb5211e1badcc4902585114ea",
+  "version_inputs_hash": "sha256:6f0b0e68ea3a99b35b288aff9906a4025186b847ad845691da274d883cb5ac3f"
 }

--- a/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 2,
   "locked_at": "2025-05-09T18:45:52.792591+00:00",
-  "other_inputs_hash": "sha256:215fad12fa31b55eef34936579a8d98cf0308e8139695509f46ad1271c25c3df",
-  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
+  "other_inputs_hash": "sha256:f1979da8937d8cf1eac917c0ed15b479f2509631748747640972df6cdab5cf25",
+  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
+  "version_inputs_hash": "sha256:ea5a6660a342a820a7c1cbced6a07c02416ec28725c68f3c5a3c47c92236da26"
 }

--- a/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 3,
   "locked_at": "2025-05-09T18:45:06.003081+00:00",
-  "other_inputs_hash": "sha256:215fad12fa31b55eef34936579a8d98cf0308e8139695509f46ad1271c25c3df",
-  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
+  "other_inputs_hash": "sha256:f1979da8937d8cf1eac917c0ed15b479f2509631748747640972df6cdab5cf25",
+  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
+  "version_inputs_hash": "sha256:ea5a6660a342a820a7c1cbced6a07c02416ec28725c68f3c5a3c47c92236da26"
 }

--- a/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-win_amd64.txt.json
+++ b/tests/sample_project/requirements/app-scipy-import/requirements-app-scipy-import-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 3,
   "locked_at": "2025-05-09T18:48:13.565042+00:00",
-  "other_inputs_hash": "sha256:215fad12fa31b55eef34936579a8d98cf0308e8139695509f46ad1271c25c3df",
-  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
+  "other_inputs_hash": "sha256:f1979da8937d8cf1eac917c0ed15b479f2509631748747640972df6cdab5cf25",
+  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
+  "version_inputs_hash": "sha256:ea5a6660a342a820a7c1cbced6a07c02416ec28725c68f3c5a3c47c92236da26"
 }

--- a/tests/sample_project/requirements/app-sklearn-import/requirements-app-sklearn-import-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/app-sklearn-import/requirements-app-sklearn-import-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
   "locked_at": "2025-05-09T18:45:53.095593+00:00",
-  "other_inputs_hash": "sha256:e7b71980b98fd39a6d0070b6e14366e4826331a4d81fd9f32f94f73d86d2a0e8",
-  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
+  "other_inputs_hash": "sha256:6b2c0c3252f57670da39b6752bc9517674c8d5be111ce87bb6cbdb5a2dd76d24",
+  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
+  "version_inputs_hash": "sha256:7b5c9548fd94dc6c2c78864c78c04393b28257c5be06c01d4ed343b082dd1cc0"
 }

--- a/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:5903fe36dad435d8fe1a0ae3e5b3ffe70377c4f958695b087a67169417edd793",
   "lock_version": 1,
   "locked_at": "2025-05-06T13:02:25.197280+00:00",
-  "other_inputs_hash": "sha256:ba2a5dacf6d1a152fc67bbbf13b64e9402fdefcfd9f5ac1b4cf4c8cb5d45ab66",
-  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
+  "other_inputs_hash": "sha256:468aeff7b25545430b927176bb1b3bada5a16a198a9a943cb5c3044399d3d7d2",
+  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
+  "version_inputs_hash": "sha256:44b4cd1d97e56b864c2ea2c41e99158b3bcbe6a2e6c6641cfef12bfdae06dbb1"
 }

--- a/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:5903fe36dad435d8fe1a0ae3e5b3ffe70377c4f958695b087a67169417edd793",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:22:40.424219+00:00",
-  "other_inputs_hash": "sha256:ba2a5dacf6d1a152fc67bbbf13b64e9402fdefcfd9f5ac1b4cf4c8cb5d45ab66",
-  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
+  "other_inputs_hash": "sha256:468aeff7b25545430b927176bb1b3bada5a16a198a9a943cb5c3044399d3d7d2",
+  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
+  "version_inputs_hash": "sha256:44b4cd1d97e56b864c2ea2c41e99158b3bcbe6a2e6c6641cfef12bfdae06dbb1"
 }

--- a/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-win_amd64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.11/requirements-cpython-3.11-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:5903fe36dad435d8fe1a0ae3e5b3ffe70377c4f958695b087a67169417edd793",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:23:53.304519+00:00",
-  "other_inputs_hash": "sha256:ba2a5dacf6d1a152fc67bbbf13b64e9402fdefcfd9f5ac1b4cf4c8cb5d45ab66",
-  "requirements_hash": "sha256:73bee58127351c581c2599ee62f96d71b5fbe8f5a85bf0b7e5f9230d6a2024d3"
+  "other_inputs_hash": "sha256:468aeff7b25545430b927176bb1b3bada5a16a198a9a943cb5c3044399d3d7d2",
+  "requirements_hash": "sha256:73bee58127351c581c2599ee62f96d71b5fbe8f5a85bf0b7e5f9230d6a2024d3",
+  "version_inputs_hash": "sha256:44b4cd1d97e56b864c2ea2c41e99158b3bcbe6a2e6c6641cfef12bfdae06dbb1"
 }

--- a/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:73dd0baf8e5438da8816254a073ee43b61f8b2cdef6f393e0059cdbc55cb8d9c",
   "lock_version": 1,
   "locked_at": "2025-05-06T13:02:25.547280+00:00",
-  "other_inputs_hash": "sha256:8ae5bf71f7991ccceeaa1c2d4256912daf3ab59fdca36bb40a7daa82734e9660",
-  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
+  "other_inputs_hash": "sha256:54c6b6749d77e791edee80826a5a00e8f90445eedb8bb20fbc14309881685a5c",
+  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
+  "version_inputs_hash": "sha256:821923ab51d157fe454e635d2e9b9645199cf06381c3a99e81c12b28ed007e31"
 }

--- a/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:73dd0baf8e5438da8816254a073ee43b61f8b2cdef6f393e0059cdbc55cb8d9c",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:22:40.497966+00:00",
-  "other_inputs_hash": "sha256:8ae5bf71f7991ccceeaa1c2d4256912daf3ab59fdca36bb40a7daa82734e9660",
-  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
+  "other_inputs_hash": "sha256:54c6b6749d77e791edee80826a5a00e8f90445eedb8bb20fbc14309881685a5c",
+  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
+  "version_inputs_hash": "sha256:821923ab51d157fe454e635d2e9b9645199cf06381c3a99e81c12b28ed007e31"
 }

--- a/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-win_amd64.txt.json
+++ b/tests/sample_project/requirements/cpython-3.12/requirements-cpython-3.12-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:73dd0baf8e5438da8816254a073ee43b61f8b2cdef6f393e0059cdbc55cb8d9c",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:23:53.458220+00:00",
-  "other_inputs_hash": "sha256:8ae5bf71f7991ccceeaa1c2d4256912daf3ab59fdca36bb40a7daa82734e9660",
-  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697"
+  "other_inputs_hash": "sha256:54c6b6749d77e791edee80826a5a00e8f90445eedb8bb20fbc14309881685a5c",
+  "requirements_hash": "sha256:4571d3f97153fc0051c989ff51b621de29854c2018b765fba6e877015a64c697",
+  "version_inputs_hash": "sha256:821923ab51d157fe454e635d2e9b9645199cf06381c3a99e81c12b28ed007e31"
 }

--- a/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:88d06260d47079c96afc2b43bf92858aa6a607350a8e8908abf9f055da609d4c",
   "lock_version": 1,
   "locked_at": "2025-05-06T13:02:26.807280+00:00",
-  "other_inputs_hash": "sha256:3e698d1f4bc88e3d22e37d35f7b37a0623510eafdfb31444513c8eda7cc48442",
-  "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0"
+  "other_inputs_hash": "sha256:c4aa5ec33ef4d68a90d7de6fd1373840a66e17f037e4b5e313f991500137ea7b",
+  "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",
+  "version_inputs_hash": "sha256:1bd591b5bbce5cae42ee3fc5d1a715396956b43e7b12c79c76abe20aab8fabd4"
 }

--- a/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:88d06260d47079c96afc2b43bf92858aa6a607350a8e8908abf9f055da609d4c",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:22:40.770077+00:00",
-  "other_inputs_hash": "sha256:3e698d1f4bc88e3d22e37d35f7b37a0623510eafdfb31444513c8eda7cc48442",
-  "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0"
+  "other_inputs_hash": "sha256:c4aa5ec33ef4d68a90d7de6fd1373840a66e17f037e4b5e313f991500137ea7b",
+  "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",
+  "version_inputs_hash": "sha256:1bd591b5bbce5cae42ee3fc5d1a715396956b43e7b12c79c76abe20aab8fabd4"
 }

--- a/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-win_amd64.txt.json
+++ b/tests/sample_project/requirements/framework-http-client/requirements-framework-http-client-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:88d06260d47079c96afc2b43bf92858aa6a607350a8e8908abf9f055da609d4c",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:23:53.734827+00:00",
-  "other_inputs_hash": "sha256:3e698d1f4bc88e3d22e37d35f7b37a0623510eafdfb31444513c8eda7cc48442",
-  "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0"
+  "other_inputs_hash": "sha256:c4aa5ec33ef4d68a90d7de6fd1373840a66e17f037e4b5e313f991500137ea7b",
+  "requirements_hash": "sha256:a925616aba798906b17e7f1cb4a32d640dd2e07efa6019c8150895a63234f6f0",
+  "version_inputs_hash": "sha256:1bd591b5bbce5cae42ee3fc5d1a715396956b43e7b12c79c76abe20aab8fabd4"
 }

--- a/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 1,
   "locked_at": "2025-05-06T13:02:25.857280+00:00",
-  "other_inputs_hash": "sha256:d8e20fdac2410eae9eb45c1bc9244f70b8f70e1b27842529250bf36f0d6eb18e",
-  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
+  "other_inputs_hash": "sha256:c4aa5ec33ef4d68a90d7de6fd1373840a66e17f037e4b5e313f991500137ea7b",
+  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
+  "version_inputs_hash": "sha256:f1546ddc7223a15c3d815d30b11fccc3759ed61c6c44a1c294ebd16370d016d2"
 }

--- a/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 2,
   "locked_at": "2025-05-06T14:22:40.574726+00:00",
-  "other_inputs_hash": "sha256:d8e20fdac2410eae9eb45c1bc9244f70b8f70e1b27842529250bf36f0d6eb18e",
-  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
+  "other_inputs_hash": "sha256:c4aa5ec33ef4d68a90d7de6fd1373840a66e17f037e4b5e313f991500137ea7b",
+  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
+  "version_inputs_hash": "sha256:f1546ddc7223a15c3d815d30b11fccc3759ed61c6c44a1c294ebd16370d016d2"
 }

--- a/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-win_amd64.txt.json
+++ b/tests/sample_project/requirements/framework-scipy/requirements-framework-scipy-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:b91780636b12da5ea37add0c8d2e659d47184fa8e70242f8d20b86e429afd6e2",
   "lock_version": 2,
   "locked_at": "2025-05-06T14:23:53.550281+00:00",
-  "other_inputs_hash": "sha256:d8e20fdac2410eae9eb45c1bc9244f70b8f70e1b27842529250bf36f0d6eb18e",
-  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217"
+  "other_inputs_hash": "sha256:c4aa5ec33ef4d68a90d7de6fd1373840a66e17f037e4b5e313f991500137ea7b",
+  "requirements_hash": "sha256:c78a4c81c6bc9afb393badf3b7ae3ab21e9ac927cfd3ab1db96978ac5eaef217",
+  "version_inputs_hash": "sha256:f1546ddc7223a15c3d815d30b11fccc3759ed61c6c44a1c294ebd16370d016d2"
 }

--- a/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-linux_x86_64.txt.json
+++ b/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-linux_x86_64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
   "locked_at": "2025-05-06T13:02:26.717280+00:00",
-  "other_inputs_hash": "sha256:84ce4ae002c4fdf983ef127b9722a29cff43226203fc5de48edb9848785cb18b",
-  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
+  "other_inputs_hash": "sha256:cee5998043a5c6f0c8e56827e112cea0668712b04ed5cf44cc34899995b2037e",
+  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
+  "version_inputs_hash": "sha256:5b84d41300436f66ea03923b8f4e046cd0fa1f000289eb9250654b085eba1b0b"
 }

--- a/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-macosx_arm64.txt.json
+++ b/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-macosx_arm64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:22:40.682717+00:00",
-  "other_inputs_hash": "sha256:84ce4ae002c4fdf983ef127b9722a29cff43226203fc5de48edb9848785cb18b",
-  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
+  "other_inputs_hash": "sha256:cee5998043a5c6f0c8e56827e112cea0668712b04ed5cf44cc34899995b2037e",
+  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
+  "version_inputs_hash": "sha256:5b84d41300436f66ea03923b8f4e046cd0fa1f000289eb9250654b085eba1b0b"
 }

--- a/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-win_amd64.txt.json
+++ b/tests/sample_project/requirements/framework-sklearn/requirements-framework-sklearn-win_amd64.txt.json
@@ -2,6 +2,7 @@
   "lock_input_hash": "sha256:197b0ff11cd452f01099e7386c8e45bc2d614da5a7bb8bc8daef5fdf8bf1fe83",
   "lock_version": 1,
   "locked_at": "2025-05-06T14:23:53.642461+00:00",
-  "other_inputs_hash": "sha256:84ce4ae002c4fdf983ef127b9722a29cff43226203fc5de48edb9848785cb18b",
-  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017"
+  "other_inputs_hash": "sha256:cee5998043a5c6f0c8e56827e112cea0668712b04ed5cf44cc34899995b2037e",
+  "requirements_hash": "sha256:5600adcb820b3f27dd6434fcd83573d2feed718732092ebb1dcd16cebed9f017",
+  "version_inputs_hash": "sha256:5b84d41300436f66ea03923b8f4e046cd0fa1f000289eb9250654b085eba1b0b"
 }

--- a/tests/test_cli_invocation.py
+++ b/tests/test_cli_invocation.py
@@ -678,7 +678,10 @@ class TestSubcommands:
             dict(clean=False),  # lock_environments
         ),
         (
-            ("--no-clean", "--no-if-needed",),
+            (
+                "--no-clean",
+                "--no-if-needed",
+            ),
             dict(lock=True, build=False, publish=False),  # select_operations
             dict(clean=False),  # lock_environments
         ),


### PR DESCRIPTION
* changes to version inputs only invalidate locks when the layer uses implicit versioning
* skip the full transitive dependency lock for versioned layers when only the layer version inputs have changed

Closes #201