### PR TITLE
Only require launch modules for target platform

### DIFF
--- a/docs/changelog.d/20250606_033815_ncoghlan_platform_specific_launch_module_checks.rst
+++ b/docs/changelog.d/20250606_033815_ncoghlan_platform_specific_launch_module_checks.rst
@@ -1,0 +1,5 @@
+Fixed
+-----
+
+- Launch module existence checks are now skipped for layers that will not
+  be built for the target build platform (reported in :issue:`204`).

--- a/tests/stack_specs/error_missing_launch_module.toml
+++ b/tests/stack_specs/error_missing_launch_module.toml
@@ -1,8 +1,13 @@
 # Ensure suitable error is raised for a missing launch module
 
+[[runtimes]]
+name = "cpython-3.11"
+python_implementation = "cpython@3.11.11"
+requirements = []
+
 [[applications]]
 name = "layer"
 # This will fail, since the launch module does not exist
 launch_module = "no_such_module.py"
-frameworks = "framework"
+runtime = "cpython-3.11"
 requirements = []


### PR DESCRIPTION
Skip launch module existence checks for layers that won't be built for the current target platform.

Also fix some incorrect comments around lock metadata migrations.

Closes #204