### PR TITLE
Refactor to allow source tree content filtering

### DIFF
--- a/src/venvstacks/_hash_content.py
+++ b/src/venvstacks/_hash_content.py
@@ -1,0 +1,85 @@
+"""Utilities for content and metadata hashing."""
+
+import hashlib
+
+from pathlib import Path
+from typing import Iterable
+
+from ._util import WalkCallable, walk_path
+
+
+def hash_strings(
+    items: Iterable[str], algorithm: str = "sha256", *, omit_prefix: bool = False
+) -> str:
+    incremental_hash = hashlib.new(algorithm)
+    for item in items:
+        incremental_hash.update(item.encode())
+    strings_hash = incremental_hash.hexdigest()
+    if omit_prefix:
+        return strings_hash
+    return f"{algorithm}:{strings_hash}"
+
+
+def hash_file_contents(
+    path: Path, algorithm: str = "sha256", *, omit_prefix: bool = False
+) -> str:
+    if not path.exists():
+        return ""
+    with path.open("rb", buffering=0) as f:
+        file_hash = hashlib.file_digest(f, algorithm).hexdigest()
+    if omit_prefix:
+        return file_hash
+    return f"{algorithm}:{file_hash}"
+
+
+def hash_file_name_and_contents(
+    path: Path, algorithm: str = "sha256", *, omit_prefix: bool = False
+) -> str:
+    if not path.exists():
+        return ""
+    incremental_hash = hashlib.new(algorithm)
+    incremental_hash.update(path.name.encode())
+    file_hash = hash_file_contents(path, algorithm)
+    incremental_hash.update(file_hash.encode())
+    file_and_name_hash = incremental_hash.hexdigest()
+    if omit_prefix:
+        return file_and_name_hash
+    return f"{algorithm}:{file_and_name_hash}"
+
+
+def hash_directory(
+    path: Path,
+    algorithm: str = "sha256",
+    *,
+    omit_prefix: bool = False,
+    walk_iter: WalkCallable | None = None,
+) -> str:
+    if walk_iter is None:
+        walk_iter = walk_path
+    incremental_hash = hashlib.new(algorithm)
+    # Python 3.11 compatibility: use os.walk instead of Path.walk
+    for this_dir, subdirs, files in walk_iter(path):
+        if not files:
+            continue
+        dir_path = Path(this_dir)
+        incremental_hash.update(dir_path.name.encode())
+        # Ensure directory tree iteration order is deterministic
+        subdirs.sort()
+        for file in sorted(files):
+            file_path = dir_path / file
+            incremental_hash.update(file_path.name.encode())
+            file_hash = hash_file_contents(file_path, algorithm)
+            incremental_hash.update(file_hash.encode())
+    dir_hash = incremental_hash.hexdigest()
+    if omit_prefix:
+        return dir_hash
+    return f"{algorithm}/{dir_hash}"
+
+
+def hash_module(path: Path, walk_iter: WalkCallable | None = None) -> str:
+    # Always use the default algorithm + algorithm prefix for module hashes
+    if path.is_file():
+        module_hash = hash_file_name_and_contents(path)
+    else:
+        module_hash = hash_directory(path, walk_iter=walk_iter)
+    return module_hash

--- a/src/venvstacks/_source_tree.py
+++ b/src/venvstacks/_source_tree.py
@@ -1,29 +1,25 @@
-"""Utilities for processing source tree content."""
+"""Utilities for filtering source tree content."""
 
 import os.path
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from pathlib import Path
-from typing import Sequence
+from typing import Protocol, Sequence
 
 from ._util import WalkIterator, walk_path
 
-############################################################################
-#  Class based API to handle source content management during tree traversal
-#  (allows `venvstacks` to be relatively transparently made "git aware")
-##############################################################################
 
+class SourceTreeContentFilter(Protocol):
+    # Making this a protocol rather than an ABC allows for both stateless
+    # class based implementations and stateful instance based implementations
 
-class SourceTreeContentFilter(ABC):
-    @classmethod
     @abstractmethod
-    def walk(cls, top: Path) -> WalkIterator:
+    def walk(self, top: Path) -> WalkIterator:
         """Path.walk replacement with source tree content filtering."""
         raise NotImplementedError
 
-    @classmethod
     @abstractmethod
-    def ignore(cls, src_dir: str, entries: Sequence[str]) -> Sequence[str]:
+    def ignore(self, src_dir: str, entries: Sequence[str]) -> Sequence[str]:
         """shutil.copytree 'ignore' callback with source tree content filtering."""
         raise NotImplementedError
 

--- a/src/venvstacks/_source_tree.py
+++ b/src/venvstacks/_source_tree.py
@@ -1,0 +1,49 @@
+"""Utilities for processing source tree content."""
+
+import os.path
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Sequence
+
+from ._util import WalkIterator, walk_path
+
+############################################################################
+#  Class based API to handle source content management during tree traversal
+#  (allows `venvstacks` to be relatively transparently made "git aware")
+##############################################################################
+
+
+class SourceTreeContentFilter(ABC):
+    @classmethod
+    @abstractmethod
+    def walk(cls, top: Path) -> WalkIterator:
+        """Path.walk replacement with source tree content filtering."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def ignore(cls, src_dir: str, entries: Sequence[str]) -> Sequence[str]:
+        """shutil.copytree 'ignore' callback with source tree content filtering."""
+        raise NotImplementedError
+
+
+class SourceTreeIgnorePycache(SourceTreeContentFilter):
+    _IGNORED_DIRS = {
+        "__pycache__",
+    }
+
+    @classmethod
+    def walk(cls, top: Path) -> WalkIterator:
+        """Walk source tree directory, ignoring __pycache__ folders."""
+        for dir_path, subdirs, files in walk_path(top):
+            if dir_path.name in cls._IGNORED_DIRS:
+                continue
+            yield dir_path, subdirs, files
+
+    @classmethod
+    def ignore(cls, src_dir: str, entries: Sequence[str]) -> Sequence[str]:
+        """shutil.copytree 'ignore' callback that ignores __pycache__ entries."""
+        if os.path.basename(src_dir) in cls._IGNORED_DIRS:
+            return entries
+        return ()

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -40,7 +40,6 @@ from typing import (
     Self,
     Sequence,
     Set,
-    Type,
     TypeVar,
     TypedDict,
 )
@@ -1246,7 +1245,7 @@ class LayerEnvBase(ABC):
     build_path: Path = field(repr=False)
     requirements_path: Path = field(repr=False)
     index_config: PackageIndexConfig = field(repr=False)
-    source_filter: Type[SourceTreeContentFilter] = field(repr=False)
+    source_filter: SourceTreeContentFilter = field(repr=False)
 
     # Derived from target path and spec in __post_init__
     env_path: Path = field(init=False)

--- a/tests/test_env_locks.py
+++ b/tests/test_env_locks.py
@@ -12,6 +12,8 @@ from typing import Any, Generator, cast
 
 from pytest_subtests import SubTests
 
+from venvstacks._hash_content import hash_strings
+
 from venvstacks.stacks import (
     BuildEnvError,
     BuildEnvironment,
@@ -20,7 +22,6 @@ from venvstacks.stacks import (
     LayerEnvBase,
     LayerVariants,
     StackSpec,
-    _hash_strings,
 )
 
 
@@ -125,7 +126,7 @@ def test_requirements_file_hashing(temp_dir_path: Path) -> None:
         "d==4.5.6",
     ]
     assert clean_requirements == expected_requirements
-    expected_hash = _hash_strings(expected_requirements)
+    expected_hash = hash_strings(expected_requirements)
     assert EnvironmentLock._hash_reqs(messy_requirements) == expected_hash
     req_input_path = temp_dir_path / "requirements.in"
     req_input_path.write_text("\n".join(messy_requirements))
@@ -250,9 +251,10 @@ def _modified_file(file_path: Path, contents: str) -> Generator[Any, None, None]
         backup_path.rename(file_path)
 
 
+@pytest.mark.slow
 def test_build_env_layer_locks(temp_dir_path: Path, subtests: SubTests) -> None:
     # Built as a monolithic tests with subtests for performance reasons
-    # (initial setup takes ~10 seconds, subsequent checks are fractions of a second)
+    # (initial setup takes 10+ seconds, subsequent checks are fractions of a second)
     launch_module_path = temp_dir_path / "launch.py"
     shutil.copyfile(EMPTY_SCRIPT_PATH, launch_module_path)
     shutil.copyfile(EMPTY_SCRIPT_PATH, temp_dir_path / "launch2.py")

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -9,11 +9,11 @@ import pytest
 from pathlib import Path
 from typing import Generator, Mapping
 
-from venvstacks.stacks import (
-    _hash_directory,
-    _hash_file_contents,
-    _hash_file_name_and_contents,
-    _hash_strings,
+from venvstacks._hash_content import (
+    hash_directory,
+    hash_file_contents,
+    hash_file_name_and_contents,
+    hash_strings,
 )
 
 ##################################
@@ -104,15 +104,15 @@ class TestStringIterableHashing:
     def test_default_hash(self) -> None:
         hash_fodder = STRINGS_TO_HASH
         expected_hash = EXPECTED_STRING_ITERABLE_HASHES[DEFAULT_ALGORITHM]
-        assert _hash_strings(hash_fodder) == f"{DEFAULT_ALGORITHM}:{expected_hash}"
-        assert _hash_strings(hash_fodder, omit_prefix=True) == expected_hash
+        assert hash_strings(hash_fodder) == f"{DEFAULT_ALGORITHM}:{expected_hash}"
+        assert hash_strings(hash_fodder, omit_prefix=True) == expected_hash
 
     @pytest.mark.parametrize("algorithm", ALGORITHMS_TO_EXPECTED_CONTENT_HASHES)
     def test_algorithm_selection(self, algorithm: str) -> None:
         hash_fodder = STRINGS_TO_HASH
         expected_hash = EXPECTED_STRING_ITERABLE_HASHES[algorithm]
-        assert _hash_strings(hash_fodder, algorithm) == f"{algorithm}:{expected_hash}"
-        assert _hash_strings(hash_fodder, algorithm, omit_prefix=True) == expected_hash
+        assert hash_strings(hash_fodder, algorithm) == f"{algorithm}:{expected_hash}"
+        assert hash_strings(hash_fodder, algorithm, omit_prefix=True) == expected_hash
 
 
 class TestFileContentHashing:
@@ -121,8 +121,8 @@ class TestFileContentHashing:
     )
     def test_default_hash(self, fname: str, expected_hash: str) -> None:
         file_path = HASH_FODDER_PATH / fname
-        assert _hash_file_contents(file_path) == f"{DEFAULT_ALGORITHM}:{expected_hash}"
-        assert _hash_file_contents(file_path, omit_prefix=True) == expected_hash
+        assert hash_file_contents(file_path) == f"{DEFAULT_ALGORITHM}:{expected_hash}"
+        assert hash_file_contents(file_path, omit_prefix=True) == expected_hash
 
     @pytest.mark.parametrize("algorithm,fname,expected_hash", EXPECTED_CONTENT_HASHES)
     def test_algorithm_selection(
@@ -130,10 +130,10 @@ class TestFileContentHashing:
     ) -> None:
         file_path = HASH_FODDER_PATH / fname
         assert (
-            _hash_file_contents(file_path, algorithm) == f"{algorithm}:{expected_hash}"
+            hash_file_contents(file_path, algorithm) == f"{algorithm}:{expected_hash}"
         )
         assert (
-            _hash_file_contents(file_path, algorithm, omit_prefix=True) == expected_hash
+            hash_file_contents(file_path, algorithm, omit_prefix=True) == expected_hash
         )
 
 
@@ -144,12 +144,10 @@ class TestFileNameAndContentHashing:
     def test_default_hash(self, fname: str, expected_hash: str) -> None:
         file_path = HASH_FODDER_PATH / fname
         assert (
-            _hash_file_name_and_contents(file_path)
+            hash_file_name_and_contents(file_path)
             == f"{DEFAULT_ALGORITHM}:{expected_hash}"
         )
-        assert (
-            _hash_file_name_and_contents(file_path, omit_prefix=True) == expected_hash
-        )
+        assert hash_file_name_and_contents(file_path, omit_prefix=True) == expected_hash
 
     @pytest.mark.parametrize("algorithm,fname,expected_hash", EXPECTED_COMBINED_HASHES)
     def test_algorithm_selection(
@@ -157,11 +155,11 @@ class TestFileNameAndContentHashing:
     ) -> None:
         file_path = HASH_FODDER_PATH / fname
         assert (
-            _hash_file_name_and_contents(file_path, algorithm)
+            hash_file_name_and_contents(file_path, algorithm)
             == f"{algorithm}:{expected_hash}"
         )
         assert (
-            _hash_file_name_and_contents(file_path, algorithm, omit_prefix=True)
+            hash_file_name_and_contents(file_path, algorithm, omit_prefix=True)
             == expected_hash
         )
 
@@ -229,37 +227,37 @@ class TestDirectoryHashing:
     def test_default_hash(self) -> None:
         dir_path = HASH_FODDER_PATH
         expected_hash = EXPECTED_DIR_HASHES[DEFAULT_ALGORITHM]
-        assert _hash_directory(dir_path) == f"{DEFAULT_ALGORITHM}/{expected_hash}"
-        assert _hash_directory(dir_path, omit_prefix=True) == expected_hash
+        assert hash_directory(dir_path) == f"{DEFAULT_ALGORITHM}/{expected_hash}"
+        assert hash_directory(dir_path, omit_prefix=True) == expected_hash
 
     @pytest.mark.parametrize("algorithm,expected_hash", EXPECTED_DIR_HASHES.items())
     def test_algorithm_selection(self, algorithm: str, expected_hash: str) -> None:
         dir_path = HASH_FODDER_PATH
-        assert _hash_directory(dir_path, algorithm) == f"{algorithm}/{expected_hash}"
-        assert _hash_directory(dir_path, algorithm, omit_prefix=True) == expected_hash
+        assert hash_directory(dir_path, algorithm) == f"{algorithm}/{expected_hash}"
+        assert hash_directory(dir_path, algorithm, omit_prefix=True) == expected_hash
 
     def test_root_dir_name_change_detected(self, cloned_dir_path: Path) -> None:
         renamed_dir_path = cloned_dir_path.with_name("something_completely_different")
         cloned_dir_path.rename(renamed_dir_path)
         unmodified_hash = EXPECTED_DIR_HASHES[DEFAULT_ALGORITHM]
-        assert _hash_directory(renamed_dir_path, omit_prefix=True) != unmodified_hash
+        assert hash_directory(renamed_dir_path, omit_prefix=True) != unmodified_hash
 
     def test_subdir_name_change_detected(self, cloned_dir_path: Path) -> None:
         subfolder_path = cloned_dir_path / "folder1"
         renamed_dir_path = subfolder_path.with_name("something_completely_different")
         subfolder_path.rename(renamed_dir_path)
         unmodified_hash = EXPECTED_DIR_HASHES[DEFAULT_ALGORITHM]
-        assert _hash_directory(cloned_dir_path, omit_prefix=True) != unmodified_hash
+        assert hash_directory(cloned_dir_path, omit_prefix=True) != unmodified_hash
 
     def test_file_name_change_detected(self, cloned_dir_path: Path) -> None:
         file_path = cloned_dir_path / "folder1/subfolder/file.txt"
         renamed_file_path = file_path.with_name("something_completely_different")
         file_path.rename(renamed_file_path)
         unmodified_hash = EXPECTED_DIR_HASHES[DEFAULT_ALGORITHM]
-        assert _hash_directory(cloned_dir_path, omit_prefix=True) != unmodified_hash
+        assert hash_directory(cloned_dir_path, omit_prefix=True) != unmodified_hash
 
     def test_file_contents_change_detected(self, cloned_dir_path: Path) -> None:
         file_path = cloned_dir_path / "folder1/subfolder/file.txt"
         file_path.write_text("This changes the directory hash")
         unmodified_hash = EXPECTED_DIR_HASHES[DEFAULT_ALGORITHM]
-        assert _hash_directory(cloned_dir_path, omit_prefix=True) != unmodified_hash
+        assert hash_directory(cloned_dir_path, omit_prefix=True) != unmodified_hash

--- a/tests/test_sample_project.py
+++ b/tests/test_sample_project.py
@@ -248,6 +248,7 @@ class TestBuildEnvironment(DeploymentTestCase):
         self.artifact_export_path = get_artifact_export_path()
         self.export_on_success = force_artifact_export()
 
+    @pytest.mark.slow
     def test_create_environments(self) -> None:
         # Faster test to check the links between build envs are set up correctly
         # (if this fails, there's no point even trying the full slow test case)


### PR DESCRIPTION
- add common `walk_path` utility function to handle `Path.walk` only being available in 3.12+
- refactor functions that previously called `os.walk` directly to accept a `walk_iter` parameter (defaulting to `None` and hence to `walk_path`)
- add a new `_source_tree` submodule
- split content hashing functions out to a new `_hash_content` submodule

Also belatedly mark a pair of 10+ second tests as slow.

Closes #214 