### PR TITLE
Include hidden items in glob when creating exclusion regex

### DIFF
--- a/src/venvstacks/_util.py
+++ b/src/venvstacks/_util.py
@@ -340,7 +340,7 @@ def find_shared_libraries(
     if walk_iter is None:
         walk_iter = walk_path
     exclusion_patterns = [
-        re.compile(_translate_glob(f"/{trailing}", recursive=True))
+        re.compile(_translate_glob(f"/{trailing}", recursive=True, include_hidden=True))
         for trailing in excluded
     ]
     py_version_nodot = "".join(py_version)


### PR DESCRIPTION
Shared lib paths on macOS are often contained within a hidden directory, for example, `PIL/.dylibs/libpng16.16.dylib'`. This PR expands the glob to exclude any shared libraries within a hidden directory.