### PR TITLE
Improve detection of outdated build environments

### DIFF
--- a/docs/api/stacks/venvstacks.stacks.ApplicationEnv.rst
+++ b/docs/api/stacks/venvstacks.stacks.ApplicationEnv.rst
@@ -9,7 +9,7 @@ venvstacks.stacks.ApplicationEnv
 
    .. autosummary::
 
-      ~FrameworkEnv.base_runtime
+      ~ApplicationEnv.base_runtime
       ~ApplicationEnv.category
       ~ApplicationEnv.env_name
       ~ApplicationEnv.env_spec

--- a/docs/api/stacks/venvstacks.stacks.FrameworkEnv.rst
+++ b/docs/api/stacks/venvstacks.stacks.FrameworkEnv.rst
@@ -5,21 +5,6 @@ venvstacks.stacks.FrameworkEnv
 
 .. autoclass:: FrameworkEnv
 
-
-   .. rubric:: Methods
-
-   .. autosummary::
-
-      ~FrameworkEnv.create_environment
-      ~FrameworkEnv.define_archive_build
-      ~FrameworkEnv.get_constraint_paths
-      ~FrameworkEnv.install_requirements
-      ~FrameworkEnv.link_base_runtime
-      ~FrameworkEnv.lock_requirements
-      ~FrameworkEnv.report_python_site_details
-      ~FrameworkEnv.request_export
-      ~FrameworkEnv.select_operations
-
    .. rubric:: Attributes
 
    .. autosummary::

--- a/docs/api/stacks/venvstacks.stacks.LayerEnvBase.rst
+++ b/docs/api/stacks/venvstacks.stacks.LayerEnvBase.rst
@@ -15,6 +15,8 @@ venvstacks.stacks.LayerEnvBase
       ~LayerEnvBase.get_constraint_paths
       ~LayerEnvBase.install_requirements
       ~LayerEnvBase.lock_requirements
+      ~LayerEnvBase.needs_build
+      ~LayerEnvBase.needs_lock
       ~LayerEnvBase.report_python_site_details
       ~LayerEnvBase.request_export
       ~LayerEnvBase.select_operations

--- a/src/venvstacks/cli.py
+++ b/src/venvstacks/cli.py
@@ -93,7 +93,7 @@ _CLI_OPT_FLAG_if_needed = Annotated[
 ]  # fmt: skip
 _CLI_OPT_FLAG_lock_if_needed = Annotated[
     bool,
-    typer.Option(help="Update stale layer lock files before building")
+    typer.Option(help="Update outdated layer lock files before building")
 ]  # fmt: skip
 _CLI_OPT_FLAG_lock = Annotated[
     bool,
@@ -390,7 +390,7 @@ def build(
     lock: _CLI_OPT_FLAG_lock = False,
 ) -> None:
     """Build (/lock/publish) Python virtual environment stacks."""
-    # Only update layer locks if the current lock is stale
+    # Only update layer locks if the current lock is outdated
     # While "--lock" is deprecated, it's a soft deprecation, so no warning is emitted
     want_lock = None if lock_if_needed or lock else False
     if include_dependencies is not None:

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -1695,6 +1695,9 @@ class LayerEnvBase(ABC):
             # Later process steps will fail if the environment is needed but missing
             # TODO?: emit a runtime warning about possible inconsistencies
             return False
+        if not self.env_path.exists():
+            # Build env is necessarily outdated if it doesn't exist yet
+            return True
         last_build_metadata = self._load_last_build_metadata()
         if last_build_metadata is None:
             # Build env is outdated if there is no recorded build metadata

--- a/tests/support.py
+++ b/tests/support.py
@@ -396,8 +396,8 @@ class DeploymentTestCase(unittest.TestCase):
             )
             if env.needs_build():
                 # Check the individual elements of the build validity check
-                build_metadata_path = env._build_metadata_path
-                self.assertTrue(build_metadata_path.exists())
+                self.assertTrue(env.env_path.exists())
+                self.assertTrue(env._build_metadata_path.exists())
                 last_metadata = env._load_last_build_metadata()
                 self.assertEqual(last_metadata, env._get_build_metadata())
                 self.fail(

--- a/tests/support.py
+++ b/tests/support.py
@@ -394,6 +394,15 @@ class DeploymentTestCase(unittest.TestCase):
             self.check_env_sys_path(
                 env_path, env_sys_path, self_contained=is_runtime_env
             )
+            if env.needs_build():
+                # Check the individual elements of the build validity check
+                build_metadata_path = env._build_metadata_path
+                self.assertTrue(build_metadata_path.exists())
+                last_metadata = env._load_last_build_metadata()
+                self.assertEqual(last_metadata, env._get_build_metadata())
+                self.fail(
+                    f"Layer {env.env_name!r} still needs building for an unknown reason"
+                )
 
     def check_deployed_environments(
         self,

--- a/tests/test_local_wheels_project.py
+++ b/tests/test_local_wheels_project.py
@@ -279,6 +279,12 @@ class TestBuildEnvironment(DeploymentTestCase):
         # Faster test to check the links between build envs are set up correctly
         # (if this fails, there's no point even trying the full slow test case)
         build_env = self.build_env
+        already_built = [
+            env.env_name
+            for env in build_env.all_environments()
+            if not env.needs_build()
+        ]
+        self.assertEqual(already_built, [])
         build_env.create_environments()
         self.check_build_environments(self.build_env.all_environments())
 

--- a/tests/test_minimal_project.py
+++ b/tests/test_minimal_project.py
@@ -564,6 +564,7 @@ class TestMinimalBuild(DeploymentTestCase):
         self.addCleanup(working_dir.cleanup)
         self.working_path = working_path = Path(working_dir.name)
         self.build_env = _define_build_env(working_path)
+        self.maxDiff = None
 
     def assertRecentlyLocked(
         self, last_locked_times: LastLockedTimes, minimum_lock_time: datetime
@@ -713,6 +714,12 @@ class TestMinimalBuild(DeploymentTestCase):
         # Faster test to check the links between build envs are set up correctly
         # (if this fails, there's no point even trying the full slow test case)
         build_env = self.build_env
+        already_built = [
+            env.env_name
+            for env in build_env.all_environments()
+            if not env.needs_build()
+        ]
+        self.assertEqual(already_built, [])
         build_env.create_environments()
         self.check_build_environments(self.build_env.all_environments())
 

--- a/tests/test_sample_project.py
+++ b/tests/test_sample_project.py
@@ -253,6 +253,12 @@ class TestBuildEnvironment(DeploymentTestCase):
         # Faster test to check the links between build envs are set up correctly
         # (if this fails, there's no point even trying the full slow test case)
         build_env = self.build_env
+        already_built = [
+            env.env_name
+            for env in build_env.all_environments()
+            if not env.needs_build()
+        ]
+        self.assertEqual(already_built, [])
         build_env.create_environments()
         self.check_build_environments(self.build_env.all_environments())
 


### PR DESCRIPTION
Avoids `--include` permitting builds against lower layers that were created in a previous build attempt, but actually building them failed.

Closes #222