### PR TITLE
Add Python 3.14 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,11 @@ jobs:
       fail-fast: false  # Always report results for all targets
       max-parallel: 12
       matrix:
-        python-version: [3.11, 3.12, 3.13, 3.14]
+        # To avoid excessive CI runs, test the oldest supported version,
+        # the newest supported version, and one intermediate version
+        # Currently, 3.12 is skipped, as that is tested when generating the
+        # expected output updates, and is also the default local test target
+        python-version: [3.11, 3.13, 3.14]
         # Note: while venvstacks nominally supports x86-64 macOS, the actual demand
         #       for that is unclear, so skip macos-12 testing until it is requested
         #       Linux and Windows aarch64 testing is more gated on runner availability

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false  # Always report results for all targets
       max-parallel: 12
       matrix:
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.11, 3.12, 3.13, 3.14]
         # Note: while venvstacks nominally supports x86-64 macOS, the actual demand
         #       for that is unclear, so skip macos-12 testing until it is requested
         #       Linux and Windows aarch64 testing is more gated on runner availability
@@ -64,6 +64,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        # Allow for pre-release testing of the next Python version
+        allow-prereleases: ${{ matrix.python-version == '3.15' }}
 
     - name: Set up Python ${{ matrix.python-version }}
       if: matrix.python-version == '3.13'
@@ -126,7 +128,7 @@ jobs:
 
     # Only run the slow tests on the oldest and newest versions
     - name: Slow tests
-      if: contains(fromJSON('["3.11", "3.13"]'), matrix.python-version)
+      if: contains(fromJSON('["3.11", "3.14"]'), matrix.python-version)
       id: slow_tests
       run: |
         export VENVSTACKS_EXPORT_TEST_ARTIFACTS="$GITHUB_WORKSPACE/export/tests"

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -62,8 +62,8 @@ jobs:
       matrix:
         # The expected test output aims to be Python version independent,
         # but CPython switched to a new zlib implementation in 3.14
-        # The first version here should match the `test` label in `tox.ini`
-        python-version: [3.12, 3.14]
+        # The version here should match the `test` label in `tox.ini`
+        python-version: [3.12]
         os: [ubuntu-22.04, windows-2022, macos-14]
         suffix: [""]
         include:

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -166,7 +166,7 @@ jobs:
       if: steps.update-test-outputs.outputs.updated
       uses: actions/upload-artifact@v4
       with:
-        name: venvstacks-test-outputs-${{ matrix.os }}
+        name: venvstacks-test-outputs-${{ matrix.os }}${{ matrix.suffix }}
         path: ${{ steps.update-test-outputs.outputs.updated }}
         # Just for passing the updated lock files to the update job
         retention-days: 1

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -137,12 +137,12 @@ jobs:
     - name: Ensure other fast tests pass
       run: |
         source "$VIRTUAL_ENV_BIN_DIR/activate"
-        python -m tox -m test -- -m "not slow and not expected_output"
+        python -m tox -- -m "not slow and not expected_output"
 
     - name: Ensure other slow tests pass
       run: |
         source "$VIRTUAL_ENV_BIN_DIR/activate"
-        python -m tox -m test -- -m "slow and not expected_output"
+        python -m tox -- -m "slow and not expected_output"
 
     - name: Update outputs
       id: update-test-outputs

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -54,15 +54,23 @@ jobs:
       # limitation: https://github.com/orgs/community/discussions/17245
       want-pr-linux: ${{ steps.set-matrix-result.outputs.want-pr-ubuntu }}
       want-pr-windows: ${{ steps.set-matrix-result.outputs.want-pr-windows }}
+      want-pr-windows-zlib-ng: ${{ steps.set-matrix-result.outputs.want-pr-windows-zlib-ng }}
       want-pr-macos: ${{ steps.set-matrix-result.outputs.want-pr-macos }}
     strategy:
       fail-fast: true  # Don't bother updating if any test run fails
       max-parallel: 3
       matrix:
-        # Expected test output is required to be Python version independent
-        # The version specified here should match the `test` label in `tox.ini`
-        python-version: [3.12]
+        # The expected test output aims to be Python version independent,
+        # but CPython switched to a new zlib implementation in 3.14
+        # The first version here should match the `test` label in `tox.ini`
+        python-version: [3.12, 3.14]
         os: [ubuntu-22.04, windows-2022, macos-14]
+        suffix: [""]
+        include:
+              # Generate an additional set of expected output on Windows
+              - os: windows-2022
+                python-version: 3.14
+                suffix: "-zlib-ng"
 
     # Check https://github.com/actions/action-versions/tree/main/config/actions
     # for latest versions if the standard actions start emitting warnings
@@ -172,7 +180,7 @@ jobs:
         output_var_name="want-pr-$(echo "$CI_TARGET" | cut -d '-' -f 1)"
         echo "$output_var_name=true"| tee -a "$GITHUB_OUTPUT"
       env:
-        CI_TARGET: ${{ matrix.os }}
+        CI_TARGET: ${{ matrix.os }}${{ matrix.suffix }}
 
   update:
     # Run this as a separate step to minimise the scope of the access token
@@ -180,7 +188,7 @@ jobs:
     needs: [timestamp, test]
     runs-on: ubuntu-22.04
     # Need to check the output for each matrix job separately due to GitHub matrix output limitations
-    if: needs.test.outputs.want-pr-linux || needs.test.outputs.want-pr-windows || needs.test.outputs.want-pr-macos
+    if: needs.test.outputs.want-pr-linux || needs.test.outputs.want-pr-windows || needs.test.outputs.want-pr-windows-zlib-ng || needs.test.outputs.want-pr-macos
     permissions:
       # Creating PRs involves more than just read permissions
       contents: write

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -58,7 +58,7 @@ jobs:
       want-pr-macos: ${{ steps.set-matrix-result.outputs.want-pr-macos }}
     strategy:
       fail-fast: true  # Don't bother updating if any test run fails
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         # The expected test output aims to be Python version independent,
         # but CPython switched to a new zlib implementation in 3.14

--- a/docs/changelog.d/20251111_022053_ncoghlan_add_py314_support.rst
+++ b/docs/changelog.d/20251111_022053_ncoghlan_add_py314_support.rst
@@ -1,0 +1,7 @@
+Added
+-----
+
+- Running on CPython 3.14 is now tested in CI. Note that due to changes in the ``zlib``
+  standard library module implementation, Windows layer archives built using
+  CPython 3.14 to run the build will typically be smaller than those produced
+  by previous versions (resolved in :issue:`293`).

--- a/docs/changelog.d/20251111_022053_ncoghlan_add_py314_support.rst
+++ b/docs/changelog.d/20251111_022053_ncoghlan_add_py314_support.rst
@@ -1,7 +1,7 @@
 Added
 -----
 
-- Running on CPython 3.14 is now tested in CI. Note that due to changes in the ``zlib``
-  standard library module implementation, Windows layer archives built using
-  CPython 3.14 to run the build will typically be smaller than those produced
-  by previous versions (resolved in :issue:`293`).
+- Running on CPython 3.14 is now tested in CI. Note that due to changes in the
+  ``zlib`` standard library module implementation, Windows layer archives built
+  using CPython 3.14 to run the build will typically be smaller than those
+  produced by previous versions (added in :pr:`247`).

--- a/docs/source-builds.rst
+++ b/docs/source-builds.rst
@@ -16,7 +16,13 @@ produces are `reproducible <https://reproducible-builds.org/>`__: if the same
 stack definition is built again later with the same
 `build environment <https://reproducible-builds.org/docs/perimeter/>`__,
 then the resulting layer archives will be byte-for-byte identical with
-those produced by the original stack build.
+those produced by the original stack build. In general, keeping the versions of
+``venvstacks``, ``uv``, and ``pbs-installer`` consistent should produce
+consistent output artifacts. Note that changing the Python runtime used to
+build the layers *may* change the hashes if the standard library's archiving
+implementation changes (for example, CPython 3.14 switched to ``zlib-ng``,
+which means most archives generated for Windows layers will be smaller than
+previous versions when generated on CPython 3.14 or later)
 
 One of the ways this is achieved is by requiring that all Python packages
 included in a stack build be provided as pre-built

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed",
 ]

--- a/tests/expected-output-config.toml
+++ b/tests/expected-output-config.toml
@@ -34,4 +34,4 @@ pbs-installer="2025.8.27"
 # Metadata updates can also be requested when the
 # expected layer content in the sample project changes
 
-# Last requested update: refactor constraint processing
+# Last requested update: Python 3.14 testing compatibility

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/app-scipy-client.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/app-scipy-client.json
@@ -1,0 +1,33 @@
+{
+  "app_launch_module": "scipy_client",
+  "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
+  "app_support_modules": [
+    {
+      "hash": "sha256:f0db47066ec1e276e17579c221969006dde88da71e26bf5ddbfae356fa7c8fe7",
+      "name": "empty"
+    },
+    {
+      "hash": "sha256:00e03ab6300d0b5c87c8ddd650e8e94b1b079faa2d106be90e2c64a54b712125",
+      "name": "app_support"
+    }
+  ],
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "fb56bfb36ccff101e42b709110c752b5b4506eefbbbcf798e7db8c548115dbf5"
+  },
+  "archive_name": "app-scipy-client.zip",
+  "archive_size": 264640,
+  "bound_to_implementation": true,
+  "install_target": "app-scipy-client",
+  "layer_name": "app-scipy-client",
+  "lock_version": 1,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.11.11",
+  "required_layers": [
+    "framework-scipy@3",
+    "framework-http-client"
+  ],
+  "requirements_hash": "sha256:b30a27e08c82c9d15a1823f8b73eccad9d4eacfe11f3111d8ab26e82d3c7550c",
+  "runtime_layer": "cpython-3.11",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/app-sklearn-import.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/app-sklearn-import.json
@@ -1,0 +1,22 @@
+{
+  "app_launch_module": "sklearn_import",
+  "app_launch_module_hash": "sha256:fcb2d3f009b6bd274509ed8830e4640aadeef0b726b6de833edc16b76a893530",
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "503e38791a63f3f5b4766ad5885a449e2b140c3dfda9e91cc6601f715d3ab036"
+  },
+  "archive_name": "app-sklearn-import.zip",
+  "archive_size": 263855,
+  "bound_to_implementation": true,
+  "install_target": "app-sklearn-import",
+  "layer_name": "app-sklearn-import",
+  "lock_version": 1,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.12.9",
+  "required_layers": [
+    "framework-sklearn"
+  ],
+  "requirements_hash": "sha256:668c5b182cb4ed6c35333882b591d8ce8bf1029ea523844ea89c41318dadfd45",
+  "runtime_layer": "cpython-3.12@2",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/cpython-3.11.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/cpython-3.11.json
@@ -1,0 +1,17 @@
+{
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "091354c237fdfff09f8355cf0ee4f18064167b24434ca900dd70a22f30b8b85e"
+  },
+  "archive_name": "cpython-3.11.zip",
+  "archive_size": 31504146,
+  "bound_to_implementation": true,
+  "install_target": "cpython-3.11",
+  "layer_name": "cpython-3.11",
+  "lock_version": 1,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.11.11",
+  "requirements_hash": "sha256:9c6a5fa5d6a44f30508ca7d9cbfc274aa949373b8fa0a278efdb8f153cc41593",
+  "runtime_layer": "cpython-3.11",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/cpython-3.12.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/cpython-3.12.json
@@ -1,0 +1,17 @@
+{
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "8c13a2e960ef9d93ca74d951e04efa47b824321bb37b571b9048ad60ec65475a"
+  },
+  "archive_name": "cpython-3.12@2.zip",
+  "archive_size": 29932375,
+  "bound_to_implementation": true,
+  "install_target": "cpython-3.12@2",
+  "layer_name": "cpython-3.12",
+  "lock_version": 2,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.12.9",
+  "requirements_hash": "sha256:40c458726a651ecc2b22bfc22927e4364b7db10a9d529ba4a79ab2b43a2d61ac",
+  "runtime_layer": "cpython-3.12@2",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/framework-http-client.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/framework-http-client.json
@@ -1,0 +1,18 @@
+{
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "0a7f6dd3057eb1c9c1a188860751023778815f65e4e6e94b7f198fb492aa992a"
+  },
+  "archive_name": "framework-http-client.zip",
+  "archive_size": 873200,
+  "bound_to_implementation": true,
+  "install_target": "framework-http-client",
+  "layer_name": "framework-http-client",
+  "lock_version": 1,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.11.11",
+  "required_layers": [],
+  "requirements_hash": "sha256:780923a1f8fe6070446184a3a0ce3d4891721ab000f7aa3f7bb94524c9beb8fa",
+  "runtime_layer": "cpython-3.11",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/framework-scipy.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/framework-scipy.json
@@ -1,0 +1,18 @@
+{
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "29126dc7efdaf593537d3e56cf5fa159b1d47945da0907d990f940fce6f03342"
+  },
+  "archive_name": "framework-scipy@3.zip",
+  "archive_size": 39855619,
+  "bound_to_implementation": true,
+  "install_target": "framework-scipy@3",
+  "layer_name": "framework-scipy",
+  "lock_version": 3,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.11.11",
+  "required_layers": [],
+  "requirements_hash": "sha256:1897027be2ff12149fe9ad3569e2a1f699dd667971113c4e3c39b285fa51615a",
+  "runtime_layer": "cpython-3.11",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/framework-sklearn.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/env_metadata/framework-sklearn.json
@@ -1,0 +1,18 @@
+{
+  "archive_build": 1,
+  "archive_hashes": {
+    "sha256": "e258a4033c72dd66fe23ea6e605ecd45e65196a6eeb9b16bc4b1cb9a86dd35d2"
+  },
+  "archive_name": "framework-sklearn.zip",
+  "archive_size": 49014616,
+  "bound_to_implementation": true,
+  "install_target": "framework-sklearn",
+  "layer_name": "framework-sklearn",
+  "lock_version": 1,
+  "locked_at": "2025-08-27T00:00:00+00:00",
+  "python_implementation": "cpython@3.12.9",
+  "required_layers": [],
+  "requirements_hash": "sha256:5561c223e76f9af34a72820bf154603936382dfd37031474553f6af17beeb2d7",
+  "runtime_layer": "cpython-3.12@2",
+  "target_platform": "win_amd64"
+}

--- a/tests/sample_project/expected_manifests/py3.14/win_amd64/venvstacks.json
+++ b/tests/sample_project/expected_manifests/py3.14/win_amd64/venvstacks.json
@@ -1,0 +1,153 @@
+{
+  "layers": {
+    "applications": [
+      {
+        "app_launch_module": "scipy_client",
+        "app_launch_module_hash": "sha256/76d203dd6d3bb1fdb1117053c81590d42ef3f62b4b92b8d316b31f08334fbca6",
+        "app_support_modules": [
+          {
+            "hash": "sha256:f0db47066ec1e276e17579c221969006dde88da71e26bf5ddbfae356fa7c8fe7",
+            "name": "empty"
+          },
+          {
+            "hash": "sha256:00e03ab6300d0b5c87c8ddd650e8e94b1b079faa2d106be90e2c64a54b712125",
+            "name": "app_support"
+          }
+        ],
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "fb56bfb36ccff101e42b709110c752b5b4506eefbbbcf798e7db8c548115dbf5"
+        },
+        "archive_name": "app-scipy-client.zip",
+        "archive_size": 264640,
+        "bound_to_implementation": true,
+        "install_target": "app-scipy-client",
+        "layer_name": "app-scipy-client",
+        "lock_version": 1,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.11.11",
+        "required_layers": [
+          "framework-scipy@3",
+          "framework-http-client"
+        ],
+        "requirements_hash": "sha256:b30a27e08c82c9d15a1823f8b73eccad9d4eacfe11f3111d8ab26e82d3c7550c",
+        "runtime_layer": "cpython-3.11",
+        "target_platform": "win_amd64"
+      },
+      {
+        "app_launch_module": "sklearn_import",
+        "app_launch_module_hash": "sha256:fcb2d3f009b6bd274509ed8830e4640aadeef0b726b6de833edc16b76a893530",
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "503e38791a63f3f5b4766ad5885a449e2b140c3dfda9e91cc6601f715d3ab036"
+        },
+        "archive_name": "app-sklearn-import.zip",
+        "archive_size": 263855,
+        "bound_to_implementation": true,
+        "install_target": "app-sklearn-import",
+        "layer_name": "app-sklearn-import",
+        "lock_version": 1,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.12.9",
+        "required_layers": [
+          "framework-sklearn"
+        ],
+        "requirements_hash": "sha256:668c5b182cb4ed6c35333882b591d8ce8bf1029ea523844ea89c41318dadfd45",
+        "runtime_layer": "cpython-3.12@2",
+        "target_platform": "win_amd64"
+      }
+    ],
+    "frameworks": [
+      {
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "29126dc7efdaf593537d3e56cf5fa159b1d47945da0907d990f940fce6f03342"
+        },
+        "archive_name": "framework-scipy@3.zip",
+        "archive_size": 39855619,
+        "bound_to_implementation": true,
+        "install_target": "framework-scipy@3",
+        "layer_name": "framework-scipy",
+        "lock_version": 3,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.11.11",
+        "required_layers": [],
+        "requirements_hash": "sha256:1897027be2ff12149fe9ad3569e2a1f699dd667971113c4e3c39b285fa51615a",
+        "runtime_layer": "cpython-3.11",
+        "target_platform": "win_amd64"
+      },
+      {
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "e258a4033c72dd66fe23ea6e605ecd45e65196a6eeb9b16bc4b1cb9a86dd35d2"
+        },
+        "archive_name": "framework-sklearn.zip",
+        "archive_size": 49014616,
+        "bound_to_implementation": true,
+        "install_target": "framework-sklearn",
+        "layer_name": "framework-sklearn",
+        "lock_version": 1,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.12.9",
+        "required_layers": [],
+        "requirements_hash": "sha256:5561c223e76f9af34a72820bf154603936382dfd37031474553f6af17beeb2d7",
+        "runtime_layer": "cpython-3.12@2",
+        "target_platform": "win_amd64"
+      },
+      {
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "0a7f6dd3057eb1c9c1a188860751023778815f65e4e6e94b7f198fb492aa992a"
+        },
+        "archive_name": "framework-http-client.zip",
+        "archive_size": 873200,
+        "bound_to_implementation": true,
+        "install_target": "framework-http-client",
+        "layer_name": "framework-http-client",
+        "lock_version": 1,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.11.11",
+        "required_layers": [],
+        "requirements_hash": "sha256:780923a1f8fe6070446184a3a0ce3d4891721ab000f7aa3f7bb94524c9beb8fa",
+        "runtime_layer": "cpython-3.11",
+        "target_platform": "win_amd64"
+      }
+    ],
+    "runtimes": [
+      {
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "091354c237fdfff09f8355cf0ee4f18064167b24434ca900dd70a22f30b8b85e"
+        },
+        "archive_name": "cpython-3.11.zip",
+        "archive_size": 31504146,
+        "bound_to_implementation": true,
+        "install_target": "cpython-3.11",
+        "layer_name": "cpython-3.11",
+        "lock_version": 1,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.11.11",
+        "requirements_hash": "sha256:9c6a5fa5d6a44f30508ca7d9cbfc274aa949373b8fa0a278efdb8f153cc41593",
+        "runtime_layer": "cpython-3.11",
+        "target_platform": "win_amd64"
+      },
+      {
+        "archive_build": 1,
+        "archive_hashes": {
+          "sha256": "8c13a2e960ef9d93ca74d951e04efa47b824321bb37b571b9048ad60ec65475a"
+        },
+        "archive_name": "cpython-3.12@2.zip",
+        "archive_size": 29932375,
+        "bound_to_implementation": true,
+        "install_target": "cpython-3.12@2",
+        "layer_name": "cpython-3.12",
+        "lock_version": 2,
+        "locked_at": "2025-08-27T00:00:00+00:00",
+        "python_implementation": "cpython@3.12.9",
+        "requirements_hash": "sha256:40c458726a651ecc2b22bfc22927e4364b7db10a9d529ba4a79ab2b43a2d61ac",
+        "runtime_layer": "cpython-3.12@2",
+        "target_platform": "win_amd64"
+      }
+    ]
+  }
+}

--- a/tests/test_env_markers.py
+++ b/tests/test_env_markers.py
@@ -17,6 +17,7 @@ def test_runtime_cpython() -> None:
     assert spec.py_implementation == "CPython"
     assert spec.py_version == "3.13.7"
 
+
 def test_runtime_pypy() -> None:
     spec = RuntimeSpec.from_dict(
         {
@@ -27,6 +28,7 @@ def test_runtime_pypy() -> None:
     )
     assert spec.py_implementation == "PyPy"
     assert spec.py_version == "3.11.13"
+
 
 # Check inference of environment markers from platform and implementation
 _EXPECTED_IMPLEMENTATION_MARKERS = {
@@ -77,6 +79,7 @@ _EXPECTED_PLATFORM_MARKERS = {
         "platform_system": "Darwin",
     },
 }
+
 
 @pytest.mark.parametrize("platform", TargetPlatforms.get_all_target_platforms())
 @pytest.mark.parametrize("impl_name", _EXPECTED_IMPLEMENTATION_MARKERS.keys())

--- a/tests/test_sample_project.py
+++ b/tests/test_sample_project.py
@@ -47,6 +47,12 @@ SAMPLE_PROJECT_PATH = _THIS_PATH.parent / "sample_project"
 SAMPLE_PROJECT_STACK_SPEC_PATH = SAMPLE_PROJECT_PATH / "venvstacks.toml"
 SAMPLE_PROJECT_REQUIREMENTS_PATH = SAMPLE_PROJECT_PATH / "requirements"
 SAMPLE_PROJECT_MANIFESTS_PATH = SAMPLE_PROJECT_PATH / "expected_manifests"
+# CPython switched to a new Windows zlib implementation in 3.14,
+# so its expected metadata is stored separately. Once 3.14 is the
+# oldest supported version, this special case can be dropped
+# (including the separate run in the update expected outputs CI job)
+if sys.version_info >= (3, 14) and sys.platform == "win32":
+    SAMPLE_PROJECT_MANIFESTS_PATH /= "py3.14"
 
 
 def _define_build_env(working_path: Path) -> BuildEnvironment:
@@ -62,12 +68,7 @@ def _define_build_env(working_path: Path) -> BuildEnvironment:
 
 def _get_expected_metadata(build_env: BuildEnvironment) -> ManifestData:
     """Path to the expected sample project archive metadata for the current platform."""
-    # CPython switched to a new Windows zlib implementation in 3.14,
-    # so its expected metadata is stored separately
-    metadata_path = SAMPLE_PROJECT_MANIFESTS_PATH / build_env.build_platform
-    if sys.version_info >= (3, 14) and sys.platform == "win32":
-        metadata_path = metadata_path / "py3.14"
-    return ManifestData(metadata_path)
+    return ManifestData(SAMPLE_PROJECT_MANIFESTS_PATH / build_env.build_platform)
 
 
 def _get_expected_dry_run_result(

--- a/tests/test_sample_project.py
+++ b/tests/test_sample_project.py
@@ -76,7 +76,7 @@ def _get_expected_dry_run_result(
 ) -> dict[str, Any]:
     # Dry run results report LayerCategories instances rather than plain strings
     untagged_metadata = _get_expected_metadata(build_env).combined_data
-    all_layer_manifests = untagged_metadata["layers"]
+    all_layer_manifests = untagged_metadata.get("layers", {})
     filtered_layer_manifests: dict[LayerCategories, Any] = {}
     for category, archive_manifests in all_layer_manifests.items():
         filtered_layer_manifests[LayerCategories(category)] = archive_manifests

--- a/tests/test_sample_project.py
+++ b/tests/test_sample_project.py
@@ -2,6 +2,7 @@
 
 import os.path
 import shutil
+import sys
 import tempfile
 
 from itertools import chain
@@ -61,7 +62,12 @@ def _define_build_env(working_path: Path) -> BuildEnvironment:
 
 def _get_expected_metadata(build_env: BuildEnvironment) -> ManifestData:
     """Path to the expected sample project archive metadata for the current platform."""
-    return ManifestData(SAMPLE_PROJECT_MANIFESTS_PATH / build_env.build_platform)
+    # CPython switched to a new Windows zlib implementation in 3.14,
+    # so its expected metadata is stored separately
+    metadata_path = SAMPLE_PROJECT_MANIFESTS_PATH / build_env.build_platform
+    if sys.version_info >= (3, 14) and sys.platform == "win32":
+        metadata_path = metadata_path / "py3.14"
+    return ManifestData(metadata_path)
 
 
 def _get_expected_dry_run_result(

--- a/tests/update-expected-output.sh
+++ b/tests/update-expected-output.sh
@@ -21,7 +21,7 @@ if [ -z "$CI" ]; then
   TOX_ENV_OPT="-m"
   TOX_ENV_MARKER="test"
 fi
-tox "$TOX_ENV_OPT" "$TOX_ENV_MARKER" -- -m "expected_output" -vvs || true
+tox $TOX_ENV_OPT $TOX_ENV_MARKER -- -m "expected_output" -vvs || true
 
 # Emit the list of changed files (if any) to the specified output file
 # Avoids setting a non-zero return code if `grep` doesn't match any lines

--- a/tests/update-expected-output.sh
+++ b/tests/update-expected-output.sh
@@ -13,7 +13,15 @@ output_target="${1:?}"
 # Ignore return code, as the tests will fail when updates are needed.
 # Make the tests explicitly chatty to allow debugging when they pass
 # unexpectedly (failing to update the output when updates are expected)
-tox -m test -- -m "expected_output" -vvs || true
+TOX_ENV_OPT=""
+TOX_ENV_MARKER=""
+CI="${CI:-}"
+if [ -z "$CI" ]; then
+  # Not running in CI, so use the default test env instead of relying on tox-gh
+  TOX_ENV_OPT="-m"
+  TOX_ENV_MARKER="test"
+fi
+tox "$TOX_ENV_OPT" "$TOX_ENV_MARKER" -- -m "expected_output" -vvs || true
 
 # Emit the list of changed files (if any) to the specified output file
 # Avoids setting a non-zero return code if `grep` doesn't match any lines

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-env_list = py{3.11,3.12,3.13},format,lint,typecheck
+env_list = py{3.11,3.12,3.13,3.14},format,lint,typecheck
 skip_missing_interpreters = False
 isolated_build = True
 labels =
      test = py3.12
      test_oldest = py3.11
-     test_latest = py3.13
-     test_all = py{3.11,3.12,3.13}
+     test_latest = py3.14
+     test_all = py{3.11,3.12,3.13,3.14}
      static = lint,typecheck
 
 [testenv]
@@ -62,5 +62,6 @@ commands =
 python =
     3.11 = py3.11
     3.12 = py3.12
+    3.13 = py3.13
     # Collect coverage stats on the newest version
-    3.13 = coverage
+    3.14 = coverage


### PR DESCRIPTION
* also add to package compatibility tags
* handle Python version induced hash differences in CI
