### PR TITLE
Fix unittest diff comparison order

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -271,12 +271,12 @@ class SpecLoadingTestCase(unittest.TestCase):
         spec_keys = runtime_keys + framework_keys + application_keys
         self.assertCountEqual(spec_keys, set(spec_keys))
         expected_spec_names = [env.spec_name for env in expected_environments]
-        self.assertCountEqual(spec_keys, expected_spec_names)
+        self.assertCountEqual(expected_spec_names, spec_keys)
         spec_names = [env.name for env in stack_spec.all_environment_specs()]
-        self.assertCountEqual(spec_names, expected_spec_names)
+        self.assertCountEqual(expected_spec_names, spec_names)
         expected_env_names = [env.env_name for env in expected_environments]
         env_names = [env.env_name for env in stack_spec.all_environment_specs()]
-        self.assertCountEqual(env_names, expected_env_names)
+        self.assertCountEqual(expected_env_names, env_names)
         for rt_summary in expected_runtimes:
             spec_name = rt_summary.spec_name
             rt_env = stack_spec.runtimes[spec_name]
@@ -302,10 +302,10 @@ class SpecLoadingTestCase(unittest.TestCase):
             self.assertEqual(fw_dep_names, app_summary.framework_spec_names)
         del spec_name, fw_dep_names, app_env, app_summary
         # Check path attributes
-        self.assertEqual(stack_spec.spec_path, expected_spec_path)
+        self.assertEqual(expected_spec_path, stack_spec.spec_path)
         expected_requirements_dir_path = expected_spec_path.parent / "requirements"
         self.assertEqual(
-            stack_spec.requirements_dir_path, expected_requirements_dir_path
+            expected_requirements_dir_path, stack_spec.requirements_dir_path
         )
 
 
@@ -389,7 +389,7 @@ class DeploymentTestCase(unittest.TestCase):
             layer_config = json.loads(config_path.read_text(encoding="utf-8"))
             env_python = env_path / layer_config["python"]
             expected_python_path = env.python_path
-            self.assertEqual(str(env_python), str(expected_python_path))
+            self.assertEqual(str(expected_python_path), str(env_python))
             base_python_path = env_path / layer_config["base_python"]
             is_runtime_env = env.kind == LayerVariants.RUNTIME
             if is_runtime_env:
@@ -407,7 +407,7 @@ class DeploymentTestCase(unittest.TestCase):
                 expected_base_python_path = Path(
                     env_path, "..", base_runtime.install_target, relative_base_python
                 )
-            self.assertEqual(str(base_python_path), str(expected_base_python_path))
+            self.assertEqual(str(expected_base_python_path), str(base_python_path))
             env_sys_path = get_sys_path(env_python)
             # Base runtime environments are expected to be self-contained
             self.check_env_sys_path(
@@ -415,7 +415,7 @@ class DeploymentTestCase(unittest.TestCase):
             )
             # Only Python executables, links and/or wrapper scripts should be present
             bin_path = env.executables_path
-            self.assertEqual(list(bin_path.iterdir()), list(bin_path.glob("python*")))
+            self.assertEqual(list(bin_path.glob("python*")), list(bin_path.iterdir()))
             # RECORD files should exist, *without* any entries for executables
             pylib_path = env.pylib_path
             if next(pylib_path.glob("*.dist-info"), None) is not None:
@@ -482,9 +482,9 @@ class DeploymentTestCase(unittest.TestCase):
             assert env_config["launch_module"] == launch_module
             launch_result = run_module(env_python, launch_module)
             # Tolerate extra trailing whitespace on stdout
-            self.assertEqual(launch_result.stdout.rstrip(), self.EXPECTED_APP_OUTPUT)
+            self.assertEqual(self.EXPECTED_APP_OUTPUT, launch_result.stdout.rstrip())
             # Nothing at all should be emitted on stderr
-            self.assertEqual(launch_result.stderr, "")
+            self.assertEqual("", launch_result.stderr)
             # Support modules should be available for import
             support_module_info = app_env.get("app_support_modules")
             if support_module_info is not None:
@@ -493,8 +493,8 @@ class DeploymentTestCase(unittest.TestCase):
                     # Any support modules used in test cases produce no output
                     # (other than potentially a newline indicator)
                     mod_exec_result = run_module(env_python, module_info["name"])
-                    self.assertEqual(mod_exec_result.stdout.rstrip(), "")
-                    self.assertEqual(mod_exec_result.stderr, "")
+                    self.assertEqual("", mod_exec_result.stdout.rstrip())
+                    self.assertEqual("", mod_exec_result.stderr)
 
     def check_environment_exports(
         self, export_path: Path, export_paths: ExportedEnvironmentPaths

--- a/tests/test_local_wheels_project.py
+++ b/tests/test_local_wheels_project.py
@@ -284,7 +284,7 @@ class TestBuildEnvironment(DeploymentTestCase):
             for env in build_env.all_environments()
             if not env.needs_build()
         ]
-        self.assertEqual(already_built, [])
+        self.assertEqual([], already_built)
         build_env.create_environments()
         self.check_build_environments(self.build_env.all_environments())
 

--- a/tests/test_minimal_project.py
+++ b/tests/test_minimal_project.py
@@ -426,7 +426,7 @@ class TestMinimalBuildConfig(unittest.TestCase):
         stack_spec = self.stack_spec
         build_env = stack_spec.define_build_environment()
         expected_build_path = stack_spec.spec_path.parent
-        self.assertEqual(build_env.build_path, expected_build_path)
+        self.assertEqual(expected_build_path, build_env.build_path)
         # The spec directory necessarily already exists
         self.assertTrue(expected_build_path.exists())
 
@@ -434,21 +434,21 @@ class TestMinimalBuildConfig(unittest.TestCase):
         stack_spec = self.stack_spec
         build_env = stack_spec.define_build_environment("custom")
         expected_build_path = stack_spec.spec_path.parent / "custom"
-        self.assertEqual(build_env.build_path, expected_build_path)
+        self.assertEqual(expected_build_path, build_env.build_path)
         # Build directory is only created when needed, not immediately
         self.assertFalse(expected_build_path.exists())
 
     def test_custom_build_directory_user(self) -> None:
         build_env = self.stack_spec.define_build_environment("~/custom")
         expected_build_path = Path.home() / "custom"
-        self.assertEqual(build_env.build_path, expected_build_path)
+        self.assertEqual(expected_build_path, build_env.build_path)
         # Build directory is only created when needed, not immediately
         self.assertFalse(expected_build_path.exists())
 
     def test_custom_build_directory_absolute(self) -> None:
         expected_build_path = Path("/custom").absolute()  # Add drive info on Windows
         build_env = self.stack_spec.define_build_environment(expected_build_path)
-        self.assertEqual(build_env.build_path, expected_build_path)
+        self.assertEqual(expected_build_path, build_env.build_path)
         # Build directory is only created when needed, not immediately
         self.assertFalse(expected_build_path.exists())
 
@@ -457,19 +457,19 @@ class TestMinimalBuildConfig(unittest.TestCase):
         build_env = stack_spec.define_build_environment()
         expected_names = [env.env_name for env in EXPECTED_ENVIRONMENTS]
         all_names = [env.env_name for env in build_env.all_environments()]
-        self.assertEqual(all_names, expected_names)
+        self.assertEqual(expected_names, all_names)
         # No lock files, so all envs should need locking
         envs_to_lock = list(build_env.environments_to_lock())
         lock_names = [env.env_name for env in envs_to_lock]
-        self.assertEqual(lock_names, expected_names)
+        self.assertEqual(expected_names, lock_names)
         self.assertTrue(all(env.needs_lock() for env in envs_to_lock))
         self.assertTrue(build_env._needs_lock())
         # All envs should be flagged for building
         build_names = [env.env_name for env in build_env.environments_to_build()]
-        self.assertEqual(build_names, expected_names)
+        self.assertEqual(expected_names, build_names)
         # All envs should be flagged for publishing
         publish_names = [env.env_name for env in build_env.environments_to_publish()]
-        self.assertEqual(publish_names, expected_names)
+        self.assertEqual(expected_names, publish_names)
 
     def test_env_categories_with_ops_disabled(self) -> None:
         stack_spec = self.stack_spec
@@ -482,15 +482,15 @@ class TestMinimalBuildConfig(unittest.TestCase):
         expected_names = [env.env_name for env in EXPECTED_ENVIRONMENTS]
         all_envs = list(build_env.all_environments())
         all_names = [env.env_name for env in all_envs]
-        self.assertEqual(all_names, expected_names)
+        self.assertEqual(expected_names, all_names)
         # No envs should be selected for locking
-        self.assertEqual(list(build_env.environments_to_lock()), [])
+        self.assertEqual([], list(build_env.environments_to_lock()))
         self.assertFalse(any(env.needs_lock() for env in all_envs))
         self.assertFalse(build_env._needs_lock())
         # No envs should be flagged for building
-        self.assertEqual(list(build_env.environments_to_build()), [])
+        self.assertEqual([], list(build_env.environments_to_build()))
         # No envs should be flagged for publishing
-        self.assertEqual(list(build_env.environments_to_publish()), [])
+        self.assertEqual([], list(build_env.environments_to_publish()))
 
     def test_get_stack_status(self) -> None:
         # Also covers testing get_env_status on the individual layers
@@ -508,7 +508,7 @@ class TestMinimalBuildConfig(unittest.TestCase):
             for layer_status in expected_stack_status_no_ops[category]:
                 layer_status["selected_operations"] = None
         stack_status_no_ops = build_env.get_stack_status(report_ops=False)
-        self.assertEqual(stack_status_no_ops, expected_stack_status_no_ops)
+        self.assertEqual(expected_stack_status_no_ops, stack_status_no_ops)
 
 
 class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
@@ -539,14 +539,14 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
     def check_publishing_request(
         self, publishing_request: StackPublishingRequest
     ) -> None:
-        self.assertEqual(_filter_manifest(publishing_request)[0], EXPECTED_MANIFEST)
+        self.assertEqual(EXPECTED_MANIFEST, _filter_manifest(publishing_request)[0])
 
     def test_default_output_directory(self) -> None:
         build_env = self.build_env
         output_path, publishing_request = build_env.publish_artifacts(dry_run=True)
         # Build folder is used as the default output directory
         expected_output_path = self.expected_build_path
-        self.assertEqual(output_path, expected_output_path)
+        self.assertEqual(expected_output_path, output_path)
         self.check_publishing_request(publishing_request)
         # The build directory necessarily already exists
         self.assertFalse(expected_output_path.exists())
@@ -557,7 +557,7 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
             "custom", dry_run=True
         )
         expected_output_path = self.working_path / "custom"
-        self.assertEqual(output_path, expected_output_path)
+        self.assertEqual(expected_output_path, output_path)
         self.check_publishing_request(publishing_request)
         # Dry run doesn't create the output directory
         self.assertFalse(expected_output_path.exists())
@@ -568,7 +568,7 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
             "~/custom", dry_run=True
         )
         expected_output_path = Path.home() / "custom"
-        self.assertEqual(output_path, expected_output_path)
+        self.assertEqual(expected_output_path, output_path)
         self.check_publishing_request(publishing_request)
         # Dry run doesn't create the output directory
         self.assertFalse(expected_output_path.exists())
@@ -579,7 +579,7 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         output_path, publishing_request = build_env.publish_artifacts(
             expected_output_path, dry_run=True
         )
-        self.assertEqual(output_path, expected_output_path)
+        self.assertEqual(expected_output_path, output_path)
         self.check_publishing_request(publishing_request)
         # Dry run doesn't create the output directory
         self.assertFalse(expected_output_path.exists())
@@ -588,20 +588,20 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         build_env = self.build_env
         expected_names = [env.env_name for env in EXPECTED_ENVIRONMENTS]
         all_names = [env.env_name for env in build_env.all_environments()]
-        self.assertEqual(all_names, expected_names)
+        self.assertEqual(expected_names, all_names)
         # Lock files exist, so no envs should *need* locking,
         # but their lock status should still be checked by default
         envs_to_lock = list(build_env.environments_to_lock())
         lock_names = [env.env_name for env in envs_to_lock]
-        self.assertEqual(lock_names, expected_names)
+        self.assertEqual(expected_names, lock_names)
         self.assertFalse(any(env.needs_lock() for env in envs_to_lock))
         self.assertFalse(build_env._needs_lock())
         # All envs should be flagged for building
         build_names = [env.env_name for env in build_env.environments_to_build()]
-        self.assertEqual(build_names, expected_names)
+        self.assertEqual(expected_names, build_names)
         # All envs should be flagged for publishing
         publish_names = [env.env_name for env in build_env.environments_to_publish()]
-        self.assertEqual(publish_names, expected_names)
+        self.assertEqual(expected_names, publish_names)
 
     def test_env_categories_lock_with_lock_reset(self) -> None:
         build_env = self.build_env
@@ -611,17 +611,17 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         )
         expected_names = [env.env_name for env in EXPECTED_ENVIRONMENTS]
         all_names = [env.env_name for env in build_env.all_environments()]
-        self.assertEqual(all_names, expected_names)
+        self.assertEqual(expected_names, all_names)
         # Lock reset requested, so all envs should need locking
         envs_to_lock = list(build_env.environments_to_lock())
         lock_names = [env.env_name for env in envs_to_lock]
-        self.assertEqual(lock_names, expected_names)
+        self.assertEqual(expected_names, lock_names)
         self.assertTrue(all(env.needs_lock() for env in envs_to_lock))
         self.assertTrue(build_env._needs_lock())
         # No envs should be flagged for building
-        self.assertEqual(list(build_env.environments_to_build()), [])
+        self.assertEqual([], list(build_env.environments_to_build()))
         # No envs should be flagged for publishing
-        self.assertEqual(list(build_env.environments_to_publish()), [])
+        self.assertEqual([], list(build_env.environments_to_publish()))
 
     def test_env_categories_lock_layers_with_lock_reset(self) -> None:
         build_env = self.build_env
@@ -637,13 +637,13 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         # Lock reset requested, so all envs should need locking
         envs_to_lock = list(build_env.environments_to_lock())
         lock_names = [env.env_name for env in envs_to_lock]
-        self.assertEqual(lock_names, all_names)
+        self.assertEqual(all_names, lock_names)
         self.assertTrue(all(env.needs_lock() for env in envs_to_lock))
         self.assertTrue(build_env._needs_lock())
         # No envs should be flagged for building
-        self.assertEqual(list(build_env.environments_to_build()), [])
+        self.assertEqual([], list(build_env.environments_to_build()))
         # No envs should be flagged for publishing
-        self.assertEqual(list(build_env.environments_to_publish()), [])
+        self.assertEqual([], list(build_env.environments_to_publish()))
 
     def test_env_categories_selective_lock_with_lock_reset(self) -> None:
         build_env = self.build_env
@@ -669,7 +669,7 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         # Ensure expected envs want and need locking
         envs_to_lock = list(build_env.environments_to_lock())
         lock_names = {env.env_name for env in envs_to_lock}
-        self.assertEqual(lock_names, all_names - no_lock)
+        self.assertEqual(all_names - no_lock, lock_names)
         self.assertTrue(
             all(
                 env.needs_lock() for env in envs_to_lock if env.env_name not in no_reset
@@ -682,7 +682,7 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         # Check the runtime environment has been added to layers to lock
         envs_to_lock = list(build_env.environments_to_lock())
         lock_names = {env.env_name for env in envs_to_lock}
-        self.assertEqual(lock_names, all_names - no_lock)
+        self.assertEqual(all_names - no_lock, lock_names)
         self.assertTrue(all(env.needs_lock() for env in envs_to_lock))
         self.assertTrue(build_env._needs_lock())
 
@@ -697,12 +697,12 @@ class TestMinimalBuildConfigWithExistingLockFiles(unittest.TestCase):
         del build_env  # Ensure all checks are run against the new instance
         expected_names = [env.env_name for env in EXPECTED_ENVIRONMENTS]
         all_names = [env.env_name for env in new_env.all_environments()]
-        self.assertEqual(all_names, expected_names)
+        self.assertEqual(expected_names, all_names)
         # Lock files still exist, so no envs should need locking
         unlocked = [
             env.env_name for env in new_env.all_environments() if env.needs_lock()
         ]
-        self.assertEqual(unlocked, [])
+        self.assertEqual([], unlocked)
         self.assertFalse(new_env._needs_lock())
 
 
@@ -773,9 +773,9 @@ class TestMinimalBuild(DeploymentTestCase):
         manifest_path, snippet_paths, archive_paths = publication_result
         # Check overall manifest file
         expected_manifest_path = expected_metadata_path / expected_metadata_name
-        self.assertEqual(manifest_path, expected_manifest_path)
+        self.assertEqual(expected_manifest_path, manifest_path)
         manifest_data = self._load_build_manifest(manifest_path)
-        self.assertEqual(manifest_data, dry_run_result)
+        self.assertEqual(dry_run_result, manifest_data)
         # Check individual archive manifests
         expected_summaries: dict[str, ArchiveSummary] = {}
         for archive_summaries in dry_run_result["layers"].values():
@@ -787,8 +787,8 @@ class TestMinimalBuild(DeploymentTestCase):
             install_target = archive_summary["install_target"]
             expected_snippet_name = f"{install_target}{expected_snippet_suffix}"
             expected_snippet_path = expected_env_metadata_path / expected_snippet_name
-            self.assertEqual(snippet_path, expected_snippet_path)
-            self.assertEqual(archive_summary, expected_summaries[install_target])
+            self.assertEqual(expected_snippet_path, snippet_path)
+            self.assertEqual(expected_summaries[install_target], archive_summary)
         # Check the names and location of the generated archives
         expected_archive_paths: list[Path] = []
         for archive_summaries in dry_run_result["layers"].values():
@@ -798,7 +798,7 @@ class TestMinimalBuild(DeploymentTestCase):
                 )
                 expected_archive_paths.append(expected_archive_path)
         expected_archive_paths.sort()
-        self.assertEqual(sorted(archive_paths), expected_archive_paths)
+        self.assertEqual(expected_archive_paths, sorted(archive_paths))
 
     @staticmethod
     def _run_postinstall(env_path: Path) -> None:
@@ -873,7 +873,7 @@ class TestMinimalBuild(DeploymentTestCase):
             for env in build_env.all_environments()
             if not env.needs_build()
         ]
-        self.assertEqual(already_built, [])
+        self.assertEqual([], already_built)
         build_env.create_environments()
         self.check_build_environments(self.build_env.all_environments())
 
@@ -926,7 +926,7 @@ class TestMinimalBuild(DeploymentTestCase):
             dry_run_result, dry_run_last_locked_times = _filter_manifest(
                 build_env.publish_artifacts(dry_run=True)[1]
             )
-            self.assertEqual(dry_run_result, expected_dry_run_result)
+            self.assertEqual(expected_dry_run_result, dry_run_result)
             self.assertRecentlyLocked(dry_run_last_locked_times, minimum_lock_time)
             # Check for expected subprocess argument lookups
             for env in self.build_env.all_environments():
@@ -943,8 +943,8 @@ class TestMinimalBuild(DeploymentTestCase):
             tagged_dry_run_result, tagged_last_locked_times = _filter_manifest(
                 build_env.publish_artifacts(dry_run=True, tag_outputs=True)[1]
             )
-            self.assertEqual(tagged_dry_run_result, expected_tagged_dry_run_result)
-            self.assertEqual(tagged_last_locked_times, dry_run_last_locked_times)
+            self.assertEqual(expected_tagged_dry_run_result, tagged_dry_run_result)
+            self.assertEqual(dry_run_last_locked_times, tagged_last_locked_times)
             subtests_passed += 1
         # Test stage: ensure lock timestamps don't change when requirements don't change
         build_env.lock_environments()
@@ -954,8 +954,8 @@ class TestMinimalBuild(DeploymentTestCase):
             stable_dry_run_result, stable_last_locked_times = _filter_manifest(
                 build_env.publish_artifacts(dry_run=True)[1]
             )
-            self.assertEqual(stable_dry_run_result, expected_dry_run_result)
-            self.assertEqual(stable_last_locked_times, dry_run_last_locked_times)
+            self.assertEqual(expected_dry_run_result, stable_dry_run_result)
+            self.assertEqual(dry_run_last_locked_times, stable_last_locked_times)
             # Check for expected subprocess argument lookups
             for env in self.build_env.all_environments():
                 # The lock file is recreated, the timestamp metadata just doesn't
@@ -979,7 +979,7 @@ class TestMinimalBuild(DeploymentTestCase):
             relocked_dry_run_result, relocked_last_locked_times = _filter_manifest(
                 build_env.publish_artifacts(dry_run=True)[1]
             )
-            self.assertEqual(relocked_dry_run_result, expected_dry_run_result)
+            self.assertEqual(expected_dry_run_result, relocked_dry_run_result)
             self.assertGreater(minimum_relock_time, minimum_lock_time)
             self.assertRecentlyLocked(relocked_last_locked_times, minimum_relock_time)
             # Check for expected subprocess argument lookups

--- a/tests/test_sample_project.py
+++ b/tests/test_sample_project.py
@@ -258,7 +258,7 @@ class TestBuildEnvironment(DeploymentTestCase):
             for env in build_env.all_environments()
             if not env.needs_build()
         ]
-        self.assertEqual(already_built, [])
+        self.assertEqual([], already_built)
         build_env.create_environments()
         self.check_build_environments(self.build_env.all_environments())
 
@@ -292,7 +292,7 @@ class TestBuildEnvironment(DeploymentTestCase):
         subtests_started += 1
         with self.subTest("Ensure lock files are reproducible"):
             self.assertEqual(
-                generated_locked_requirements, committed_locked_requirements
+                committed_locked_requirements, generated_locked_requirements
             )
             export_locked_requirements = self.export_on_success  # Only export if forced
             subtests_passed += 1
@@ -310,12 +310,12 @@ class TestBuildEnvironment(DeploymentTestCase):
         with self.subTest("Ensure archive publication requests are reproducible"):
             # Check generation of untagged archive names
             dry_run_result = build_env.publish_artifacts(dry_run=True)[1]
-            self.assertEqual(dry_run_result, expected_dry_run_result)
+            self.assertEqual(expected_dry_run_result, dry_run_result)
             # Check generation of tagged archive names
             tagged_dry_run_result = build_env.publish_artifacts(
                 dry_run=True, tag_outputs=True
             )[1]
-            self.assertEqual(tagged_dry_run_result, expected_tagged_dry_run_result)
+            self.assertEqual(expected_tagged_dry_run_result, tagged_dry_run_result)
             # Dry run metadata may be incorrect because the expected outputs are being updated,
             # so always continue on and execute the full archive publication subtest
             subtests_passed += 1
@@ -326,7 +326,7 @@ class TestBuildEnvironment(DeploymentTestCase):
             # No changes to lock files
             post_rebuild_locked_requirements = _collect_locked_requirements(build_env)
             self.assertEqual(
-                post_rebuild_locked_requirements, generated_locked_requirements
+                generated_locked_requirements, post_rebuild_locked_requirements
             )
             subtests_passed += 1
         # Test stage: ensure built artifacts have the expected manifest contents
@@ -339,12 +339,12 @@ class TestBuildEnvironment(DeploymentTestCase):
                 manifest_path.parent, snippet_paths
             )
             self.assertEqual(
-                generated_archive_metadata.combined_data,
                 expected_archive_metadata.combined_data,
+                generated_archive_metadata.combined_data,
             )
             self.assertCountEqual(
-                generated_archive_metadata.snippet_data,
                 expected_archive_metadata.snippet_data,
+                generated_archive_metadata.snippet_data,
             )
             # Archive should be emitted for every environment defined for this platform
             num_environments = len(list(build_env.all_environments()))
@@ -353,7 +353,7 @@ class TestBuildEnvironment(DeploymentTestCase):
             # No changes to lock files
             post_publish_locked_requirements = _collect_locked_requirements(build_env)
             self.assertEqual(
-                post_publish_locked_requirements, generated_locked_requirements
+                generated_locked_requirements, post_publish_locked_requirements
             )
             subtests_passed += 1
         if export_published_archives:
@@ -434,13 +434,13 @@ class TestBuildEnvironment(DeploymentTestCase):
             for env in build_env.all_environments():
                 subtests_started += 1
                 with self.subTest(env=env.env_name, requested=requested):
-                    self.assertEqual(env.want_lock, want_lock, "want_lock mismatch")
+                    self.assertEqual(want_lock, env.want_lock, "want_lock mismatch")
                     self.assertTrue(
                         env.want_lock_reset, "want_lock_reset should be True"
                     )
-                    self.assertEqual(env.want_build, want_build, "want_build mismatch")
+                    self.assertEqual(want_build, env.want_build, "want_build mismatch")
                     self.assertEqual(
-                        env.want_publish, want_publish, "want_publish mismatch"
+                        want_publish, env.want_publish, "want_publish mismatch"
                     )
                     subtests_passed += 1
         self.assertEqual(
@@ -456,13 +456,13 @@ class TestBuildEnvironment(DeploymentTestCase):
             if not (name := env.env_name).startswith("framework-s")
         )
         self.assertNotEqual(expected_layers, set())
-        self.assertEqual(build_env.filter_layers(matching), (expected_layers, set()))
+        self.assertEqual((expected_layers, set()), build_env.filter_layers(matching))
         unknown = ["unknown", "app-?", "*-app"]
         unknown_set = set(unknown)
-        self.assertEqual(build_env.filter_layers(unknown), (set(), unknown_set))
+        self.assertEqual((set(), unknown_set), build_env.filter_layers(unknown))
         combined = sorted(matching + unknown)
         self.assertEqual(
-            build_env.filter_layers(combined), (expected_layers, unknown_set)
+            (expected_layers, unknown_set), build_env.filter_layers(combined)
         )
 
     def test_layer_selection(self) -> None:


### PR DESCRIPTION
Structured diffs in the stdlib unittest module expected the actual value to be on the left
(so missing values are shown as removals, and added values are shown as additions).