### PR TITLE
Suppress noisy traceback output

### DIFF
--- a/src/venvstacks/cli.py
+++ b/src/venvstacks/cli.py
@@ -8,11 +8,12 @@ from typing import Annotated, Iterable, Sequence
 import typer
 
 from .stacks import (
-    StackSpec,
     BuildEnvironment,
-    _format_json,
-    PackageIndexConfig,
+    EnvStackError,
     EnvNameBuild,
+    PackageIndexConfig,
+    StackSpec,
+    _format_json,
     _UI,
 )
 from ._ui.render import format_stack_status
@@ -739,6 +740,11 @@ def main(args: Sequence[str] | None = None) -> None:
 
     If *args* is not given, defaults to using ``sys.argv``.
     """
-    # Indirectly calls the relevant click.Command variant's `main` method
-    # See https://click.palletsprojects.com/en/8.1.x/api/#click.BaseCommand.main
-    _cli(args, windows_expand_args=False)
+    try:
+        # Indirectly calls the relevant click.Command variant's `main` method
+        # See https://click.palletsprojects.com/en/8.1.x/api/#click.BaseCommand.main
+        _cli(args, windows_expand_args=False)
+    except EnvStackError as exc:
+        exc_type = type(exc)
+        print(f"{exc_type.__module__}.{exc_type.__name__}: {exc}")
+        sys.exit(1)

--- a/tests/stack_specs/.gitignore
+++ b/tests/stack_specs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore local builds of these files
+requirements
+_build*
+_export*

--- a/tests/stack_specs/lock_failure_conflict_between_layers.toml
+++ b/tests/stack_specs/lock_failure_conflict_between_layers.toml
@@ -1,0 +1,17 @@
+# Ensure suitable error is raised when layers fail to lock
+
+[[runtimes]]
+name = "cpython-3.11"
+python_implementation = "cpython@3.11.11"
+requirements = [
+    # Set up a potential version conflict with the upper layer
+    "numpy < 2.0",
+]
+
+[[frameworks]]
+name = "numpy"
+runtime = "cpython-3.11"
+requirements = [
+    # Ensure layer locking fails due to the version constraint imposed by the lower layer
+    "numpy >= 2.0",
+]

--- a/tests/stack_specs/lock_failure_conflict_within_layer.toml
+++ b/tests/stack_specs/lock_failure_conflict_within_layer.toml
@@ -1,0 +1,10 @@
+# Ensure suitable error is raised when layers fail to lock
+
+[[runtimes]]
+name = "cpython-3.11"
+python_implementation = "cpython@3.11.11"
+requirements = [
+    # Ensure layer locking fails by specifying incompatible requirements
+    "numpy < 2.0",
+    "numpy >= 2.0",
+]

--- a/tests/test_stack_specs.py
+++ b/tests/test_stack_specs.py
@@ -1,10 +1,14 @@
 """Test loading assorted stack specifications."""
 
 from pathlib import Path
+from typing import Generator
+
+import shutil
+import tempfile
 
 import pytest
 
-from venvstacks.stacks import LayerSpecError, StackSpec
+from venvstacks.stacks import LayerLockError, LayerSpecError, StackSpec
 
 ##################################
 # Stack spec loading test helpers
@@ -15,9 +19,14 @@ _THIS_PATH = Path(__file__)
 TEST_SPEC_PATH = _THIS_PATH.parent / "stack_specs"
 
 
-def _load_stack_spec(spec_name: str) -> StackSpec:
+def _load_stack_spec(spec_name: str, *, working_path: Path | None = None) -> StackSpec:
     """Load the named stack specification."""
-    spec_path = TEST_SPEC_PATH / spec_name
+    source_spec_path = TEST_SPEC_PATH / spec_name
+    if working_path is None:
+        spec_path = source_spec_path
+    else:
+        spec_path = working_path / spec_name
+        shutil.copyfile(source_spec_path, spec_path)
     return StackSpec.load(spec_path)
 
 
@@ -62,43 +71,55 @@ def test_future_warning_for_build_requirements() -> None:
         assert not hasattr(layer, "build_requirements")
 
 
-EXPECTED_ERRORS = {
-    "error_inconsistent_runtimes.toml": (LayerSpecError, "inconsistent frameworks"),
-    "error_launch_support_conflict.toml": (
-        LayerSpecError,
-        "'name'.*conflicts with.*'layer'",
-    ),
-    "error_layer_dep_C3_conflict.toml": (
-        LayerSpecError,
-        "linearization failed.*['layerC', 'layerD'].*['layerD', 'layerC']",
-    ),
-    "error_layer_dep_cycle.toml": (LayerSpecError, "unknown framework"),
-    "error_layer_dep_forward_reference.toml": (LayerSpecError, "unknown framework"),
-    "error_missing_launch_module.toml": (
-        LayerSpecError,
-        "launch module.*does not exist",
-    ),
-    "error_missing_support_modules.toml": (
-        LayerSpecError,
-        "support modules do not exist",
-    ),
-    "error_support_modules_conflict.toml": (
-        LayerSpecError,
-        "Conflicting support module names.*'layer'",
-    ),
-    "error_unknown_framework.toml": (LayerSpecError, "unknown framework"),
-    "error_unknown_runtime.toml": (LayerSpecError, "unknown runtime"),
+EXPECTED_STACK_SPEC_ERRORS = {
+    "error_inconsistent_runtimes.toml": "inconsistent frameworks",
+    "error_launch_support_conflict.toml": "'name'.*conflicts with.*'layer'",
+    "error_layer_dep_C3_conflict.toml": "linearization failed.*['layerC', 'layerD'].*['layerD', 'layerC']",
+    "error_layer_dep_cycle.toml": "unknown framework",
+    "error_layer_dep_forward_reference.toml": "unknown framework",
+    "error_missing_launch_module.toml": "launch module.*does not exist",
+    "error_missing_support_modules.toml": "support modules do not exist",
+    "error_support_modules_conflict.toml": "Conflicting support module names.*'layer'",
+    "error_unknown_framework.toml": "unknown framework",
+    "error_unknown_runtime.toml": "unknown runtime",
 }
 
 
-def test_error_case_results_are_defined() -> None:
+def test_stack_spec_error_case_results_are_defined() -> None:
     # Ensure any new error cases that are added have expected errors defined
-    defined_error_cases = sorted(p.name for p in TEST_SPEC_PATH.glob("error_*"))
-    assert defined_error_cases == sorted(EXPECTED_ERRORS)
+    spec_error_cases = sorted(p.name for p in TEST_SPEC_PATH.glob("error_*"))
+    assert spec_error_cases == sorted(EXPECTED_STACK_SPEC_ERRORS)
 
 
-@pytest.mark.parametrize("spec_path", EXPECTED_ERRORS)
-def test_stack_spec_error_case(spec_path: str) -> None:
-    expected_exc, expected_match = EXPECTED_ERRORS[spec_path]
-    with pytest.raises(expected_exc, match=expected_match):
-        _load_stack_spec(spec_path)
+@pytest.mark.parametrize("spec_fname", EXPECTED_STACK_SPEC_ERRORS)
+def test_stack_spec_error_case(spec_fname: str) -> None:
+    expected_match = EXPECTED_STACK_SPEC_ERRORS[spec_fname]
+    with pytest.raises(LayerSpecError, match=expected_match):
+        _load_stack_spec(spec_fname)
+
+
+EXPECTED_LOCK_FAILURES = {
+    "lock_failure_conflict_between_layers.toml": "Failed to lock layer 'framework-numpy'",
+    "lock_failure_conflict_within_layer.toml": "Failed to lock layer 'cpython-3.11'",
+}
+
+
+@pytest.fixture
+def temp_dir_path() -> Generator[Path, None, None]:
+    with tempfile.TemporaryDirectory() as dir_name:
+        yield Path(dir_name)
+
+
+def test_lock_failure_case_results_are_defined() -> None:
+    # Ensure any new op failure cases that are added have expected errors defined
+    lock_failure_cases = sorted(p.name for p in TEST_SPEC_PATH.glob("lock_failure_*"))
+    assert lock_failure_cases == sorted(EXPECTED_LOCK_FAILURES)
+
+
+@pytest.mark.parametrize("spec_fname", EXPECTED_LOCK_FAILURES)
+def test_lock_failure_case(temp_dir_path: Path, spec_fname: str) -> None:
+    expected_match = EXPECTED_LOCK_FAILURES[spec_fname]
+    with pytest.raises(LayerLockError, match=expected_match):
+        stack_spec = _load_stack_spec(spec_fname, working_path=temp_dir_path)
+        build_env = stack_spec.define_build_environment()
+        build_env.lock_environments()


### PR DESCRIPTION
Library-specific exceptions can be located based on the exception type and error message details, so printing full tracebacks is pure UX noise.

Closes #243