### PR TITLE
Make canonical enum names singular

### DIFF
--- a/docs/api/stacks/index.rst
+++ b/docs/api/stacks/index.rst
@@ -43,7 +43,9 @@
       :nosignatures:
 
       LayerCategories
+      LayerCategory
       LayerSpecMetadata
+      LayerVariant
       LayerVariants
       TargetPlatform
       TargetPlatforms

--- a/docs/api/stacks/venvstacks.stacks.LayerCategories.rst
+++ b/docs/api/stacks/venvstacks.stacks.LayerCategories.rst
@@ -1,15 +1,4 @@
 venvstacks.stacks.LayerCategories
 =================================
 
-.. currentmodule:: venvstacks.stacks
-
-.. autoclass:: LayerCategories
-
-   .. rubric:: Attributes
-
-   .. autosummary::
-
-      ~LayerCategories.RUNTIMES
-      ~LayerCategories.FRAMEWORKS
-      ~LayerCategories.APPLICATIONS
-
+Readability alias for :class:`~venvstacks.stacks.LayerCategory`

--- a/docs/api/stacks/venvstacks.stacks.LayerCategory.rst
+++ b/docs/api/stacks/venvstacks.stacks.LayerCategory.rst
@@ -1,0 +1,14 @@
+venvstacks.stacks.LayerCategory
+===============================
+
+.. currentmodule:: venvstacks.stacks
+
+.. autoclass:: LayerCategory
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~LayerCategory.RUNTIMES
+      ~LayerCategory.FRAMEWORKS
+      ~LayerCategory.APPLICATIONS

--- a/docs/api/stacks/venvstacks.stacks.LayerVariant.rst
+++ b/docs/api/stacks/venvstacks.stacks.LayerVariant.rst
@@ -1,0 +1,14 @@
+venvstacks.stacks.LayerVariant
+==============================
+
+.. currentmodule:: venvstacks.stacks
+
+.. autoclass:: LayerVariant
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~LayerVariant.RUNTIME
+      ~LayerVariant.FRAMEWORK
+      ~LayerVariant.APPLICATION

--- a/docs/api/stacks/venvstacks.stacks.LayerVariants.rst
+++ b/docs/api/stacks/venvstacks.stacks.LayerVariants.rst
@@ -1,15 +1,4 @@
 venvstacks.stacks.LayerVariants
 ===============================
 
-.. currentmodule:: venvstacks.stacks
-
-.. autoclass:: LayerVariants
-
-   .. rubric:: Attributes
-
-   .. autosummary::
-
-      ~LayerVariants.RUNTIME
-      ~LayerVariants.FRAMEWORK
-      ~LayerVariants.APPLICATION
-
+Readability alias for :class:`~venvstacks.stacks.LayerVariant`

--- a/docs/api/stacks/venvstacks.stacks.TargetPlatform.rst
+++ b/docs/api/stacks/venvstacks.stacks.TargetPlatform.rst
@@ -13,4 +13,3 @@ venvstacks.stacks.TargetPlatform
       ~TargetPlatform.LINUX
       ~TargetPlatform.MACOS_APPLE
       ~TargetPlatform.MACOS_INTEL
-

--- a/docs/api/stacks/venvstacks.stacks.TargetPlatforms.rst
+++ b/docs/api/stacks/venvstacks.stacks.TargetPlatforms.rst
@@ -1,16 +1,4 @@
 venvstacks.stacks.TargetPlatforms
 =================================
 
-.. currentmodule:: venvstacks.stacks
-
-.. autoclass:: TargetPlatforms
-
-   .. rubric:: Attributes
-
-   .. autosummary::
-
-      ~TargetPlatforms.WINDOWS
-      ~TargetPlatforms.LINUX
-      ~TargetPlatforms.MACOS_APPLE
-      ~TargetPlatforms.MACOS_INTEL
-
+Readability alias for :class:`~venvstacks.stacks.TargetPlatform`

--- a/docs/changelog.d/20251105_000551_ncoghlan_make_canonical_enum_names_singular.rst
+++ b/docs/changelog.d/20251105_000551_ncoghlan_make_canonical_enum_names_singular.rst
@@ -1,0 +1,6 @@
+Changed
+-------
+
+- To improve type hints reported in IDEs and errors reported by static type
+  checking, enums now use their singular form as their canonical name,
+  with the plural form available as an alias (changed in :pr:`308`).

--- a/src/venvstacks/stacks.py
+++ b/src/venvstacks/stacks.py
@@ -183,15 +183,15 @@ _UV_PYTHON_PLATFORM_NAMES = {
 # Identify target platforms using strings based on
 # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#basic-platform-tags
 # macOS target system API version info is omitted (as that will be set universally for macOS builds)
-class TargetPlatforms(StrEnum):
-    """Enum for support target deployment platforms."""
+class TargetPlatform(StrEnum):
+    """Enum for supported target deployment platforms."""
 
-    WINDOWS = "win_amd64"
+    WINDOWS = "win_amd64"  # Tested in CI
     WINDOWS_ARM64 = "win_arm64"
-    LINUX = "linux_x86_64"
+    LINUX = "linux_x86_64"  # Tested in CI
     LINUX_AARCH64 = "linux_aarch64"
-    MACOS_APPLE = "macosx_arm64"
-    MACOS_INTEL = "macosx_x86_64"  # Note: not currently tested in CI!
+    MACOS_APPLE = "macosx_arm64"  # Tested in CI
+    MACOS_INTEL = "macosx_x86_64"
 
     @classmethod
     def get_all_target_platforms(cls) -> list[Self]:
@@ -218,9 +218,8 @@ class TargetPlatforms(StrEnum):
         return f"{uv_arch}-{uv_platform}"
 
 
-TargetPlatform = (
-    TargetPlatforms  # Use singular name when creating instances from values
-)
+TargetPlatforms = TargetPlatform  # Use plural alias when the singular name reads oddly
+
 _UV_PYTHON_PLATFORMS = {
     platform: platform._as_uv_python_platform()
     for platform in TargetPlatforms.get_all_target_platforms()
@@ -1092,7 +1091,7 @@ class EnvironmentLock:
         return diagnostics
 
 
-class LayerVariants(StrEnum):
+class LayerVariant(StrEnum):
     """Enum for defined layer variants."""
 
     RUNTIME = "runtime"
@@ -1100,12 +1099,18 @@ class LayerVariants(StrEnum):
     APPLICATION = "application"
 
 
-class LayerCategories(StrEnum):
+LayerVariants = LayerVariant  # Use plural alias when the singular name reads oddly
+
+
+class LayerCategory(StrEnum):
     """Enum for defined layer categories (collections of each variant)."""
 
     RUNTIMES = "runtimes"
     FRAMEWORKS = "frameworks"
     APPLICATIONS = "applications"
+
+
+LayerCategories = LayerCategory  # Use plural alias when the singular name reads oddly
 
 
 def ensure_optional_env_spec_fields(env_metadata: MutableMapping[str, Any]) -> None:
@@ -1125,8 +1130,8 @@ class LayerSpecBase(ABC):
     ENV_PREFIX = ""
 
     # Specified in concrete subclasses
-    kind: ClassVar[LayerVariants]
-    category: ClassVar[LayerCategories]
+    kind: ClassVar[LayerVariant]
+    category: ClassVar[LayerCategory]
 
     # Specified on creation (typically based on TOML layer spec fields)
     name: LayerBaseName
@@ -1815,8 +1820,8 @@ class LayerEnvBase(ABC):
     tools_python_path: ClassVar[Path] = Path(sys.executable)
 
     # Specified in concrete subclasses
-    kind: ClassVar[LayerVariants]
-    category: ClassVar[LayerCategories]
+    kind: ClassVar[LayerVariant]
+    category: ClassVar[LayerCategory]
 
     # Specified on creation
     _env_spec: LayerSpecBase = field(repr=False)


### PR DESCRIPTION
Working on #303 showed that having the plural forms as the canonical enum names reads oddly in type hints when hovering over variables or reading static type check failure messages.

The plural forms are retained as aliases for backwards compatibility and because they genuinely read better when working with enum classes as a collection of enum values.