### PR TITLE
Sort entries in index file generated by `gen_repo_links.py`

### DIFF
--- a/misc/gen_repo_links.py
+++ b/misc/gen_repo_links.py
@@ -85,7 +85,7 @@ def get_project_artifact_info(project_details_path: Path) -> Sequence[ArtifactLi
                 "sha256": sha256_hash.hexdigest(),
             }
         )
-    return artifact_details
+    return sorted(artifact_details, key=lambda x: x["name"])
 
 
 def write_project_detail_file(project_details_path: Path) -> Path:


### PR DESCRIPTION
When iterating for the directory, files are added to the sequence in a non-deterministic order, which produces irrelevant diffs when regenerating the index.html files